### PR TITLE
Downsize db pool size to 2 from 10.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/db/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/db/Database.kt
@@ -47,6 +47,7 @@ abstract class Database(val daoConfig: DbConfig, private val initBlock: ((contex
             username = daoConfig.username
             password = daoConfig.password
             maximumPoolSize = daoConfig.poolSize
+            minimumIdle = 1
             isAutoCommit = false
             transactionIsolation = "TRANSACTION_REPEATABLE_READ"
             validate()


### PR DESCRIPTION
- The shared postgresql instance do have a limit to 100 connections
- 2 is sufficient (will be reused) - and depends upon the data intensive this app is.