### PR TITLE
Receive event oversikthendelsetilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -27,7 +27,7 @@ fun getEnvironment(): Environment {
                 getEnvVar("DATABASE_NAME", "syfooversiktsrv"),
                 getEnvVar("SYFOOVERSIKTSRV_DB_URL"),
                 getEnvVar("MOUNT_PATH_VAULT"),
-                getEnvVar("KAFKA_OVERSIKT_HENDELSE_V1_TOPIC", "privat-syfo-sm2013-register"),
+                getEnvVar("OVERSIKTHENDELSE_OPPFOLGINGSTILFELLE_TOPIC", "aapen-syfo-oversikthendelse-tilfelle-v1"),
                 getEnvVar("KAFKA_BOOTSTRAP_SERVERS_URL"),
                 getEnvVar("CLIENT_ID")
         )
@@ -48,7 +48,7 @@ data class Environment(
         val databaseName: String,
         val syfooversiktsrvDBURL: String,
         val mountPathVault: String,
-        val oversiktHendelseTopic: String,
+        val oversikthendelseOppfolgingstilfelleTopic: String,
         override val kafkaBootstrapServers: String,
         val clientid: String
 ) : KafkaConfig

--- a/src/main/kotlin/no/nav/syfo/SyfooversiktApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/SyfooversiktApplication.kt
@@ -35,6 +35,7 @@ import no.nav.syfo.api.registerNaisApi
 import no.nav.syfo.auth.*
 import no.nav.syfo.db.*
 import no.nav.syfo.kafka.setupKafka
+import no.nav.syfo.oversikthendelsetilfelle.OversikthendelstilfelleService
 import no.nav.syfo.personstatus.*
 import no.nav.syfo.tilgangskontroll.MidlertidigTilgangsSjekk
 import no.nav.syfo.tilgangskontroll.TilgangskontrollConsumer
@@ -153,11 +154,12 @@ fun Application.kafkaModule() {
     isProd {
 
         val oversiktHendelseService = OversiktHendelseService(database)
+        val oversikthendelstilfelleService = OversikthendelstilfelleService(database)
 
         launch(backgroundTasksContext) {
             val vaultSecrets =
                     objectMapper.readValue<VaultSecrets>(Paths.get("/var/run/secrets/nais.io/vault/credentials.json").toFile())
-            setupKafka(vaultSecrets, oversiktHendelseService)
+            setupKafka(vaultSecrets, oversiktHendelseService, oversikthendelstilfelleService)
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
@@ -25,6 +25,14 @@ const val OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_OPPDATER = "oversi
 const val OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_OPPDATER_ENHET = "oversikthendelse_moteplanlegger_alle_svar_behandlet_oppdater_enhet_count"
 const val OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_FEILET = "oversikthendelse_moteplanlegger_alle_svar_behandlet_feilet_count"
 
+const val OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPRETT = "oversikthendelsetilfelle_ingen_aktivitet_opprett_count"
+const val OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPDATER = "oversikthendelsetilfelle_ingen_aktivitet_oppdater_count"
+const val OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_ENHET = "oversikthendelsetilfelle_ingen_aktivitet_oppdater_enhet_count"
+
+const val OVERSIKTHENDELSETILFELLE_GRADERT_OPPRETT = "oversikthendelsetilfelle_gradert_opprett_count"
+const val OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER = "oversikthendelsetilfelle_gradert_oppdater_count"
+const val OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER_ENHET = "oversikthendelsetilfelle_gradert_oppdater_enhet_count"
+
 const val OVERSIKTHENDELSE_UKJENT_MOTTATT = "oversikthendelse_ukjent_count"
 
 val COUNT_PERSONTILDELING_TILDEL: Counter = Counter.build()
@@ -119,4 +127,38 @@ val COUNT_OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_FEILET: Counter = 
         .namespace(METRICS_NS)
         .name(OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_FEILET)
         .help("Counts the number of oversikthendelse of type moteplanlegger-alle-svar-behandlet that failed to update missing person")
+        .register()
+
+
+val COUNT_OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPRETT: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name(OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPRETT)
+        .help("Counts the number of oversikthendelsetilfeller  with Ingen Aktivitetresulting in creation of PERSON_OVERSIKT_STATUS row")
+        .register()
+val COUNT_OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPDATER: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name(OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPDATER)
+        .help("Counts the number of oversikthendelsetilfeller with Ingen Aktivitet resulting in update}")
+        .register()
+val COUNT_OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPDATER_ENHET: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name(OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_ENHET)
+        .help("Counts the number of oversikthendelsetilfeller  with Ingen Aktivitet resulting in update with new enhetId}")
+        .register()
+
+
+val COUNT_OVERSIKTHENDELSETILFELLE_GRADERT_OPPRETT: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name(OVERSIKTHENDELSETILFELLE_GRADERT_OPPRETT)
+        .help("Counts the number of graderte oversikthendelsetilfeller resulting in creation of PERSON_OVERSIKT_STATUS row")
+        .register()
+val COUNT_OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name(OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER)
+        .help("Counts the number of graderte oversikthendelsetilfeller resulting in update}")
+        .register()
+val COUNT_OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER_ENHET: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name(OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER_ENHET)
+        .help("Counts the number of graderte oversikthendelsetilfeller resulting in update with new enhetId}")
         .register()

--- a/src/main/kotlin/no/nav/syfo/oversikthendelsetilfelle/OversikthendelstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelsetilfelle/OversikthendelstilfelleService.kt
@@ -1,0 +1,56 @@
+package no.nav.syfo.oversikthendelsetilfelle
+
+import no.nav.syfo.LOG
+import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.metric.*
+import no.nav.syfo.oversikthendelsetilfelle.domain.KOversikthendelsetilfelle
+import no.nav.syfo.personstatus.OversiktHendelseService.Companion.erPersonsEnhetOppdatert
+import no.nav.syfo.personstatus.hentPersonResultat
+import no.nav.syfo.util.CallIdArgument
+
+class OversikthendelstilfelleService(private val database: DatabaseInterface) {
+
+    fun oppdaterPersonMedHendelse(oversikthendelsetilfelle: KOversikthendelsetilfelle, callId: String = "") {
+        if (oversikthendelsetilfelle.gradert) {
+            oppdaterPersonMedHendelseOppfolgingstilfelleGradertMottatt(oversikthendelsetilfelle, callId)
+        } else {
+            oppdaterPersonMedHendelseOppfolgingstilfelleIngenAktivitetMottatt(oversikthendelsetilfelle, callId)
+        }
+    }
+
+    private fun oppdaterPersonMedHendelseOppfolgingstilfelleIngenAktivitetMottatt(oversikthendelsetilfelle: KOversikthendelsetilfelle, callId: String) {
+        val person = database.hentPersonResultat(oversikthendelsetilfelle.fnr)
+        when {
+            person.isEmpty() -> {
+                LOG.info("Opprettet person basert pa oversikthendelsetilfelle med ingen aktivitet, for enhet {}, {}", oversikthendelsetilfelle.enhetId, CallIdArgument(callId))
+                COUNT_OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPRETT.inc()
+            }
+            erPersonsEnhetOppdatert(person, oversikthendelsetilfelle.enhetId) -> {
+                LOG.info("Oppdatert person basert pa oversikthendelsetilfelle med ingen aktivitet mottatt med ny enhet, {}", CallIdArgument(callId))
+                COUNT_OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPDATER_ENHET.inc()
+            }
+            else -> {
+                LOG.info("Oppdatert person basert pa oversikthendelsetilfelle med ingen aktivitet mottatt, {}", CallIdArgument(callId))
+                COUNT_OVERSIKTHENDELSETILFELLE_INGEN_AKTIVITET_OPPDATER.inc()
+            }
+        }
+    }
+
+    private fun oppdaterPersonMedHendelseOppfolgingstilfelleGradertMottatt(oversikthendelsetilfelle: KOversikthendelsetilfelle, callId: String) {
+        val person = database.hentPersonResultat(oversikthendelsetilfelle.fnr)
+        when {
+            person.isEmpty() -> {
+                LOG.info("Opprettet person basert pa gradert oversikthendelsetilfelle, for enhet {}, {}", oversikthendelsetilfelle.enhetId, CallIdArgument(callId))
+                COUNT_OVERSIKTHENDELSETILFELLE_GRADERT_OPPRETT.inc()
+            }
+            erPersonsEnhetOppdatert(person, oversikthendelsetilfelle.enhetId) -> {
+                LOG.info("Oppdatert person basert pa gradert oversikthendelsetilfelle mottatt med ny enhet, {}", CallIdArgument(callId))
+                COUNT_OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER_ENHET.inc()
+            }
+            else -> {
+                LOG.info("Oppdatert person basert pa gradert oversikthendelsetilfelle mottatt, {}", CallIdArgument(callId))
+                COUNT_OVERSIKTHENDELSETILFELLE_GRADERT_OPPDATER.inc()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oversikthendelsetilfelle/domain/KOversikthendelsetilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelsetilfelle/domain/KOversikthendelsetilfelle.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.oversikthendelsetilfelle.domain
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class KOversikthendelsetilfelle(
+        val fnr: String,
+        val enhetId: String,
+        val virksomhetsnummer: String,
+        val gradert: Boolean,
+        val fom: LocalDate,
+        val tom: LocalDate,
+        val tidspunkt: LocalDateTime
+)

--- a/src/main/kotlin/no/nav/syfo/personstatus/OversiktHendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/OversiktHendelseService.kt
@@ -31,7 +31,7 @@ class OversiktHendelseService(private val database: DatabaseInterface) {
                 log.info("Opprettet person basert pa oversikthendelse med moteplanlegger alle svar mottatt, {}", CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_MOTTATT_OPPRETT.inc()
             }
-            erPersonsEnhetOppdatert(person, oversiktHendelse) -> {
+            erPersonsEnhetOppdatert(person, oversiktHendelse.enhetId) -> {
                 database.oppdaterPersonMedMoteplanleggerAlleSvarNyEnhet(oversiktHendelse)
                 log.info("Oppdatert person basert pa oversikthendelse med moteplanlegger alle svar mottatt med ny enhet, {}", CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_MOTTATT_OPPDATER_ENHET.inc()
@@ -51,7 +51,7 @@ class OversiktHendelseService(private val database: DatabaseInterface) {
                 log.error("Fant ikke person som skal oppdateres med hendelse {}, for enhet {}", oversiktHendelse.hendelseId, oversiktHendelse.enhetId)
                 COUNT_OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_FEILET.inc()
             }
-            erPersonsEnhetOppdatert(person, oversiktHendelse) -> {
+            erPersonsEnhetOppdatert(person, oversiktHendelse.enhetId) -> {
                 database.oppdaterPersonMedMoteplanleggerAlleSvarBehandletNyEnhet(oversiktHendelse)
                 log.info("Oppdatert person basert pa oversikthendelse med moteplanleggersvar behandlet med ny enhet, {}", CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET_OPPDATER_ENHET.inc()
@@ -71,7 +71,7 @@ class OversiktHendelseService(private val database: DatabaseInterface) {
                 log.error("Fant ikke person som skal oppdateres med hendelse {}, for enhet {}, {}", oversiktHendelse.hendelseId, oversiktHendelse.enhetId, CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEBEHOVSSVAR_BEHANDLET_FEILET.inc()
             }
-            erPersonsEnhetOppdatert(person, oversiktHendelse) -> {
+            erPersonsEnhetOppdatert(person, oversiktHendelse.enhetId) -> {
                 database.oppdaterPersonMedMotebehovBehandletNyEnhet(oversiktHendelse)
                 log.info("Oppdatert person basert pa oversikthendelse med motebehovsvar behandlet med ny enhet, {}", CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEBEHOVSSVAR_BEHANDLET_OPPDATER_ENHET.inc()
@@ -92,7 +92,7 @@ class OversiktHendelseService(private val database: DatabaseInterface) {
                 log.info("Opprettet person basert pa oversikthendelse med motebehovsvar mottatt, {}", CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEBEHOV_SVAR_MOTTATT_OPPRETT.inc()
             }
-            erPersonsEnhetOppdatert(person, oversiktHendelse) -> {
+            erPersonsEnhetOppdatert(person, oversiktHendelse.enhetId) -> {
                 database.oppdaterPersonMedMotebehovMottattNyEnhet(oversiktHendelse)
                 log.info("Oppdatert person basert pa oversikthendelse med motebehovsvar mottatt med ny enhet, {}", CallIdArgument(callId))
                 COUNT_OVERSIKTHENDELSE_MOTEBEHOV_SVAR_MOTTATT_OPPDATER_ENHET.inc()
@@ -105,9 +105,11 @@ class OversiktHendelseService(private val database: DatabaseInterface) {
         }
     }
 
-    fun erPersonsEnhetOppdatert(person: List<PersonOversiktStatus>, oversiktHendelse: KOversikthendelse): Boolean {
-        val enhet = person[0].enhet
-        val nyEnhet = oversiktHendelse.enhetId
-        return nyEnhet.isNotEmpty() && nyEnhet != enhet
+    companion object {
+
+        fun erPersonsEnhetOppdatert(person: List<PersonOversiktStatus>, nyEnhetId: String): Boolean {
+            val enhet = person[0].enhet
+            return nyEnhetId.isNotEmpty() && nyEnhetId != enhet
+        }
     }
 }

--- a/src/main/resources/localEnvForTests.json
+++ b/src/main/resources/localEnvForTests.json
@@ -11,6 +11,6 @@
     "syfooversiktsrvDBURL": "url",
     "mountPathVault": "mountpath",
     "kafkaBootstrapServers": "kafkaurl",
-    "oversiktHendelseTopic": "topic",
+    "oversikthendelseOppfolgingstilfelleTopic": "topic-oversikthendelse-oppfolgingstilfelle",
     "clientid": "999999"
 }

--- a/src/test/kotlin/no/nav/syfo/KafkaITSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/KafkaITSpek.kt
@@ -32,7 +32,7 @@ object KafkaITSpek : Spek({
     val env = Environment(
             applicationPort = getRandomPort(),
             applicationThreads = 1,
-            oversiktHendelseTopic = "topic1",
+            oversikthendelseOppfolgingstilfelleTopic = "topic1",
             kafkaBootstrapServers = embeddedEnvironment.brokersURL,
             syfooversiktsrvDBURL = "12314.adeo.no",
             mountPathVault = "vault.adeo.no",


### PR DESCRIPTION
Dette er første del av mottatt av oppfolgingstilfelle som oversikthendelse i syfooversikt.
Denne delen inkluderer kun mottak og tellere av ulike varianter av hendelsene, uten noe endringer i database.