### PR TITLE
Return PersonOversiktStatus with oppfolgingsplanLPSBistandUbehand=true

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonOversiktStatusAksesseringQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonOversiktStatusAksesseringQueries.kt
@@ -48,7 +48,7 @@ const val queryHentUbehandledePersonerTilknyttetEnhet = """
                         SELECT *
                         FROM PERSON_OVERSIKT_STATUS
                         WHERE ((tildelt_enhet = ?)
-                        AND (motebehov_ubehandlet = 't' OR moteplanlegger_ubehandlet = 't'))
+                        AND (motebehov_ubehandlet = 't' OR moteplanlegger_ubehandlet = 't' OR oppfolgingsplan_lps_bistand_ubehandlet = 't'))
                 """
 
 fun DatabaseInterface.hentUbehandledePersonerTilknyttetEnhet(enhet: String): List<PPersonOversiktStatus> {

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
@@ -17,7 +17,7 @@ class PersonoversiktStatusService(
             }
             mapPersonOversiktStatus(it, oppfolgingstilfeller)
         }.filter {
-            it.oppfolgingstilfeller.isNotEmpty()
+            it.oppfolgingsplanLPSBistandUbehandlet == true || it.oppfolgingstilfeller.isNotEmpty()
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusApiSpek.kt
@@ -505,6 +505,34 @@ object PersonoversiktStatusApiSpek : Spek({
                         checkPersonOppfolgingstilfelle(personOversiktStatus.oppfolgingstilfeller.first(), oversikthendelstilfelle)
                     }
                 }
+
+                it("should return Person, no Oppfolgingstilfelle, and then OPPFOLGINGSPLANLPS_BISTAND_MOTTATT") {
+                    every {
+                        isInvalidToken(any())
+                    } returns false
+                    every {
+                        getTokenFromCookie(any())
+                    } returns "token"
+
+                    val oversiktHendelseOPLPSBistandMottatt = generateKOversikthendelse(OversikthendelseType.OPPFOLGINGSPLANLPS_BISTAND_MOTTATT)
+                    oversiktHendelseService.oppdaterPersonMedHendelse(oversiktHendelseOPLPSBistandMottatt)
+
+                    with(handleRequest(HttpMethod.Get, url) {
+                        call.request.cookies[cookies]
+                    }) {
+                        response.status() shouldEqual HttpStatusCode.OK
+                        val personOversiktStatus = objectMapper.readValue<List<PersonOversiktStatus>>(response.content!!).first()
+                        personOversiktStatus.veilederIdent shouldEqual null
+                        personOversiktStatus.fnr shouldEqual oversiktHendelseOPLPSBistandMottatt.fnr
+                        personOversiktStatus.navn shouldEqual ""
+                        personOversiktStatus.enhet shouldEqual oversiktHendelseOPLPSBistandMottatt.enhetId
+                        personOversiktStatus.motebehovUbehandlet shouldEqual null
+                        personOversiktStatus.moteplanleggerUbehandlet shouldEqual null
+                        personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldEqual true
+
+                        personOversiktStatus.oppfolgingstilfeller.size shouldEqual 0
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
All persons with oppfolgingsplanLPSBistandUbehandlet=true should be returned in hentPersonoversiktStatusTilknyttetEnhet even though no Oppfolgingstilfelle exists on the PersonOversiktStatus. OppfolgingsplanLPSBistand that are Ubehandle should be shown to a Veileder of a Enhet because it is not a requirement for a person to be sick, to have been sick or to have received Sykepenger.