### PR TITLE
Øker timeout som midlertidig fiks

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -3,12 +3,16 @@ package no.nav.syfo.client
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import no.nav.syfo.util.configuredJacksonMapper
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner
 import java.net.ProxySelector
 
 fun httpClientDefault() = HttpClient(CIO) {
+    install(HttpTimeout) {
+        requestTimeoutMillis = 30000
+    }
     install(JsonFeature) {
         serializer = JacksonSerializer(configuredJacksonMapper())
     }


### PR DESCRIPTION
Da enkelte rådgivere ikke får syfooversikt opp i det hele, tenker jeg vi øker timeout til 30 sek med en gang (default er 15) - og forsøker å nøste opp i ytelseproblemene i egen oppgave.