### PR TITLE
 Create table and add columns for latest Oppfolgingstilfelle

### DIFF
--- a/src/main/resources/db/migration/V11_4__add_columns_tilfelle_and_create_table_tilfelle_virksomhet.sql
+++ b/src/main/resources/db/migration/V11_4__add_columns_tilfelle_and_create_table_tilfelle_virksomhet.sql
@@ -1,0 +1,20 @@
+ALTER TABLE PERSON_OVERSIKT_STATUS
+ADD COLUMN oppfolgingstilfelle_updated_at               timestamptz,
+ADD COLUMN oppfolgingstilfelle_generated_at             timestamptz,
+ADD COLUMN oppfolgingstilfelle_start                    DATE,
+ADD COLUMN oppfolgingstilfelle_end                      DATE,
+ADD COLUMN oppfolgingstilfelle_bit_referanse_uuid       CHAR(36),
+ADD COLUMN oppfolgingstilfelle_bit_referanse_inntruffet timestamptz;
+
+CREATE TABLE PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET
+(
+    id                        SERIAL PRIMARY KEY,
+    uuid                      CHAR(36)    NOT NULL UNIQUE,
+    created_at                timestamptz NOT NULL,
+    person_oversikt_status_id INTEGER REFERENCES PERSON_OVERSIKT_STATUS (id) ON DELETE CASCADE,
+    virksomhetsnummer         CHAR(9)     NOT NULL,
+    virksomhetsnavn           VARCHAR,
+    CONSTRAINT PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET_UNIQUE UNIQUE (person_oversikt_status_id, virksomhetsnummer)
+);
+
+CREATE INDEX IX_PERSON_TILFELLE_VIRKSOMHET_ID ON PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET (person_oversikt_status_id);


### PR DESCRIPTION
Add columns in PERSON_OVERSKT_STATUS to store relevant information about the latest Oppfolgingstilfelle of a Person.
The latest Oppfolgingstilfelle will be consmed  from topic isoppfolgingstilfelle-oppfolgingstilfelle-person. Also create table PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET to store a list of Virksomhet from latest Oppfolgingstilfelle of  a Person. Virksomhet has a non-null Virksomhetsnummer from the latest Oppfolgingstilfelle and a nullable Virksomhetsnavn that will be retrieved from Ereg where needed.
