### PR TITLE
Create resuable InternalMockEnvironment for tests

### DIFF
--- a/src/test/kotlin/no/nav/syfo/personstatus/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -2,10 +2,11 @@ package no.nav.syfo.personstatus
 
 import io.ktor.server.testing.*
 import io.ktor.util.*
-import io.mockk.*
+import io.mockk.clearMocks
+import io.mockk.every
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
-import no.nav.syfo.oppfolgingstilfelle.kafka.*
+import no.nav.syfo.oppfolgingstilfelle.kafka.OPPFOLGINGSTILFELLE_PERSON_TOPIC
 import no.nav.syfo.personstatus.domain.OversikthendelseType
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
@@ -17,7 +18,8 @@ import no.nav.syfo.testutil.generator.generateKOversikthendelse
 import no.nav.syfo.testutil.generator.generateKafkaOppfolgingstilfellePerson
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
-import org.apache.kafka.clients.consumer.*
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.common.TopicPartition
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -36,14 +38,12 @@ object KafkaOppfolgingstilfellePersonServiceSpek : Spek({
             externalMockEnvironment = externalMockEnvironment,
         )
 
-        val oversiktHendelseService = OversiktHendelseService(
-            database = database,
-        )
-        val kafkaOppfolgingstilfellePersonService = KafkaOppfolgingstilfellePersonService(
-            database = database,
-        )
+        val internalMockEnvironment = InternalMockEnvironment.instance
 
-        val mockKafkaConsumerOppfolgingstilfellePerson = mockk<KafkaConsumer<String, KafkaOppfolgingstilfellePerson>>()
+        val oversiktHendelseService = internalMockEnvironment.oversiktHendelseService
+        val kafkaOppfolgingstilfellePersonService = internalMockEnvironment.kafkaOppfolgingstilfellePersonService
+
+        val mockKafkaConsumerOppfolgingstilfellePerson = internalMockEnvironment.kafkaConsumerOppfolgingstilfellePerson
 
         val partition = 0
         val oppfolgingstilfellePersonTopicPartition = TopicPartition(

--- a/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.testutil
+
+import io.mockk.mockk
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.behandlendeenhet.BehandlendeEnhetClient
+import no.nav.syfo.client.ereg.EregClient
+import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetCronjob
+import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
+import no.nav.syfo.cronjob.virksomhetsnavn.PersonOppfolgingstilfelleVirksomhetnavnCronjob
+import no.nav.syfo.cronjob.virksomhetsnavn.PersonOppfolgingstilfelleVirksomhetsnavnService
+import no.nav.syfo.oppfolgingstilfelle.kafka.KafkaOppfolgingstilfellePerson
+import no.nav.syfo.oppfolgingstilfelle.kafka.KafkaOppfolgingstilfellePersonService
+import no.nav.syfo.personstatus.OversiktHendelseService
+import org.apache.kafka.clients.consumer.KafkaConsumer
+
+class InternalMockEnvironment private constructor() {
+    private val externalMockEnvironment: ExternalMockEnvironment = ExternalMockEnvironment.instance
+    private val database = externalMockEnvironment.database
+    private val environment = externalMockEnvironment.environment
+
+    private val redisStore = RedisStore(
+        redisEnvironment = environment.redis,
+    )
+    private val azureAdClient = AzureAdClient(
+        azureEnviroment = environment.azure,
+        redisStore = redisStore,
+    )
+    private val behandlendeEnhetClient = BehandlendeEnhetClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = environment.clients.syfobehandlendeenhet,
+    )
+    private val eregClient = EregClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = environment.clients.isproxy,
+        redisStore = redisStore,
+    )
+
+    val kafkaOppfolgingstilfellePersonService = KafkaOppfolgingstilfellePersonService(
+        database = database,
+    )
+    val kafkaConsumerOppfolgingstilfellePerson = mockk<KafkaConsumer<String, KafkaOppfolgingstilfellePerson>>()
+
+    val oversiktHendelseService = OversiktHendelseService(
+        database = database,
+    )
+
+    private val personBehandlendeEnhetService = PersonBehandlendeEnhetService(
+        database = database,
+        behandlendeEnhetClient = behandlendeEnhetClient,
+    )
+    val personBehandlendeEnhetCronjob = PersonBehandlendeEnhetCronjob(
+        personBehandlendeEnhetService = personBehandlendeEnhetService,
+    )
+
+    private val personOppfolgingstilfelleVirksomhetsnavnService = PersonOppfolgingstilfelleVirksomhetsnavnService(
+        database = database,
+        eregClient = eregClient,
+    )
+    val personOppfolgingstilfelleVirksomhetnavnCronjob = PersonOppfolgingstilfelleVirksomhetnavnCronjob(
+        personOppfolgingstilfelleVirksomhetsnavnService = personOppfolgingstilfelleVirksomhetsnavnService,
+    )
+
+    companion object {
+        val instance: InternalMockEnvironment by lazy {
+            InternalMockEnvironment()
+        }
+    }
+}


### PR DESCRIPTION
A singleton instance of InternalMockEnvironment containing internal classes used in tests, is created and used in all tests to avoid repetitive initialization.