### PR TITLE
Add specific index for enhetens oversikt

### DIFF
--- a/src/main/resources/db/migration/V12_4__add_index_enhetens_oversikt.sql
+++ b/src/main/resources/db/migration/V12_4__add_index_enhetens_oversikt.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT
+ON PERSON_OVERSIKT_STATUS (tildelt_enhet, dialogmotekandidat_generated_at)
+WHERE (motebehov_ubehandlet OR moteplanlegger_ubehandlet OR oppfolgingsplan_lps_bistand_ubehandlet OR dialogmotekandidat);


### PR DESCRIPTION
Ser at noen tilfeller i produksjon fortsatt tar 10-20 sekunder, selv om snittet er 2-3 sekunder. Tror en slik partiell indeks vil forbedre det betydelig.