### PR TITLE
Bugfix: oppdater oppfolgingstilfelle ved lik inntruffet-timestamp

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -9,6 +9,7 @@ import org.apache.kafka.clients.consumer.*
 import org.slf4j.LoggerFactory
 import java.sql.Connection
 import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 class KafkaOppfolgingstilfellePersonService(
     val database: DatabaseInterface,
@@ -131,7 +132,15 @@ class KafkaOppfolgingstilfellePersonService(
             } ?: true
         } else {
             exisitingPPersonOversiktStatus.oppfolgingstilfelleBitReferanseInntruffet?.let {
-                newOppfolgingstilfelle.oppfolgingstilfelleBitReferanseInntruffet.isAfter(it)
+                val existingInntruffet = it.truncatedTo(ChronoUnit.MILLIS)
+                val newInntruffet = newOppfolgingstilfelle.oppfolgingstilfelleBitReferanseInntruffet.truncatedTo(ChronoUnit.MILLIS)
+                if (newInntruffet == existingInntruffet) {
+                    exisitingPPersonOversiktStatus.oppfolgingstilfelleGeneratedAt?.let {
+                        newOppfolgingstilfelle.generatedAt.isAfter(it)
+                    } ?: true
+                } else {
+                    newInntruffet.isAfter(existingInntruffet)
+                }
             } ?: true
         }
     }

--- a/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
@@ -507,7 +507,7 @@ object PersonBehandlendeEnhetCronjobSpek : Spek({
                     )
                     database.updateTildeltEnhetUpdatedAt(
                         ident = PersonIdent(oversikthendelse.fnr),
-                        time = nowUTC().minusHours(23),
+                        time = nowUTC().minusHours(22),
                     )
 
                     runBlocking {

--- a/src/test/kotlin/no/nav/syfo/personstatus/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -460,8 +460,6 @@ object KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                 kafkaOppfolgingstilfellePersonService.pollAndProcessRecords(
                     kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
                 )
-
-
                 val recordValueSecond = kafkaOppfolgingstilfellePersonServiceRecordRelevantSecond.value()
 
                 database.connection.use { connection ->
@@ -496,7 +494,6 @@ object KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                     pPersonOppfolgingstilfelleVirksomhetList.first().virksomhetsnummer.value shouldBeEqualTo recordValueSecond.oppfolgingstilfelleList.first().virksomhetsnummerList.first()
                 }
-
             }
 
             it("should only update latest OppfolgingstilfellPerson with the newest createdAt, if multiple relevant records on same personIdent with same referanseTilfelleBitUuid is received in different polls ") {

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -68,7 +68,7 @@ fun testEnvironment(
     ),
     redis = RedisEnvironment(
         host = "localhost",
-        port = 6379,
+        port = 6372,
         secret = "password",
     ),
     serviceuserUsername = "",

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -68,7 +68,7 @@ fun testEnvironment(
     ),
     redis = RedisEnvironment(
         host = "localhost",
-        port = 6372,
+        port = 6379,
         secret = "password",
     ),
     serviceuserUsername = "",

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/KafkaOppfolgingstilfellePersonGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/KafkaOppfolgingstilfellePersonGenerator.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.util.nowUTC
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import java.util.*
 
 fun generateKafkaOppfolgingstilfellePerson(
@@ -36,7 +37,7 @@ fun generateKafkaOppfolgingstilfellePerson(
             ),
         ),
         referanseTilfelleBitUuid = UUID.randomUUID().toString(),
-        referanseTilfelleBitInntruffet = nowUTC().minusDays(1),
+        referanseTilfelleBitInntruffet = nowUTC().minusDays(1).truncatedTo(ChronoUnit.MILLIS),
     )
 }
 


### PR DESCRIPTION
Dette relaterer seg til en jira-sak der oppfølgingstilfellet i syfoversikt fikk lengde 1 uke, mens arbeidstakeren hadde vært sykmeldt mye lengre.

Dette kunne skje når to påfølgende oppdateringer fra Kafka hadde samme inntruffet-tidsstempel.