### PR TITLE
Add columns for aktivitetskrav

### DIFF
--- a/src/main/resources/db/migration/V12_6__add_aktivitetskrav.sql
+++ b/src/main/resources/db/migration/V12_6__add_aktivitetskrav.sql
@@ -1,0 +1,4 @@
+ALTER TABLE PERSON_OVERSIKT_STATUS
+ADD COLUMN aktivitetskrav VARCHAR(30),
+ADD COLUMN aktivitetskrav_stoppunkt DATE,
+ADD COLUMN aktivitetskrav_updated_at timestamptz;


### PR DESCRIPTION
`aktivitetskrav` is the status - "NY", "OPPFYLT", etc.
`stoppunkt` is the day the innbygger passes 8 weeks syketilfelle.
`updated_at` is the time of the last change on aktivitetskrav.