### PR TITLE
Initialize redis and azureClient in App

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -9,8 +9,10 @@ import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.api.apiModule
 import no.nav.syfo.application.api.authentication.getWellKnown
+import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.database.database
 import no.nav.syfo.application.database.databaseModule
+import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.cronjob.launchCronjobModule
 import no.nav.syfo.kafka.launchKafkaModule
 import org.slf4j.LoggerFactory
@@ -25,6 +27,15 @@ fun main() {
     val environment = Environment()
     val wellKnownVeilederV2 = getWellKnown(
         wellKnownUrl = environment.azure.appWellKnownUrl,
+    )
+
+    val redisStore = RedisStore(
+        redisEnvironment = environment.redis,
+    )
+
+    val azureAdClient = AzureAdClient(
+        azureEnvironment = environment.azure,
+        redisStore = redisStore,
     )
 
     val applicationEngineEnvironment = applicationEngineEnvironment {
@@ -44,6 +55,8 @@ fun main() {
                 database = database,
                 environment = environment,
                 wellKnownVeilederV2 = wellKnownVeilederV2,
+                redisStore = redisStore,
+                azureAdClient = azureAdClient,
             )
         }
     }
@@ -64,6 +77,8 @@ fun main() {
             applicationState = applicationState,
             database = database,
             environment = environment,
+            redisStore = redisStore,
+            azureAdClient = azureAdClient,
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -21,6 +21,8 @@ fun Application.apiModule(
     database: DatabaseInterface,
     environment: Environment,
     wellKnownVeilederV2: WellKnown,
+    redisStore: RedisStore,
+    azureAdClient: AzureAdClient,
 ) {
     installCallId()
     installContentNegotiation()
@@ -39,15 +41,6 @@ fun Application.apiModule(
 
     val personTildelingService = PersonTildelingService(
         database = database,
-    )
-
-    val redisStore = RedisStore(
-        redisEnvironment = environment.redis,
-    )
-
-    val azureAdClient = AzureAdClient(
-        azureEnvironment = environment.azure,
-        redisStore = redisStore,
     )
 
     val pdlClient = PdlClient(

--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -18,15 +18,9 @@ fun launchCronjobModule(
     applicationState: ApplicationState,
     database: DatabaseInterface,
     environment: Environment,
+    redisStore: RedisStore,
+    azureAdClient: AzureAdClient,
 ) {
-    val redisStore = RedisStore(
-        redisEnvironment = environment.redis,
-    )
-
-    val azureAdClient = AzureAdClient(
-        azureEnvironment = environment.azure,
-        redisStore = redisStore,
-    )
 
     val eregClient = EregClient(
         clientEnvironment = environment.clients.ereg,

--- a/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
@@ -2,14 +2,24 @@ package no.nav.syfo.testutil
 
 import io.ktor.server.application.*
 import no.nav.syfo.application.api.apiModule
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.azuread.AzureAdClient
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment
 ) {
+    val redisStore = RedisStore(externalMockEnvironment.environment.redis)
+    val azureAdClient = AzureAdClient(
+        azureEnvironment = externalMockEnvironment.environment.azure,
+        redisStore = redisStore,
+    )
+
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,
         database = externalMockEnvironment.database,
         environment = externalMockEnvironment.environment,
         wellKnownVeilederV2 = externalMockEnvironment.wellKnownVeilederV2,
+        redisStore = redisStore,
+        azureAdClient = azureAdClient,
     )
 }


### PR DESCRIPTION
I stedet for å initialisere disse rundt omkring i appen, så flyttes det til å initialiseres i App. Det _kan_ være noe state knyttet til Redisstore som det er greit å beholde.