### PR TITLE
Update or override and delete from identhendelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/identhendelse/database/IdenthendelseQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/database/IdenthendelseQuery.kt
@@ -23,3 +23,43 @@ fun DatabaseInterface.updatePersonOversiktStatusFnr(nyPersonident: PersonIdent, 
     }
     return updatedRows
 }
+
+const val queryUpdatePersonOversiktStatusVeileder =
+    """
+        UPDATE PERSON_OVERSIKT_STATUS
+        SET tildelt_veileder = ?
+        WHERE fnr = ?
+    """
+
+fun DatabaseInterface.updatePersonOversiktStatusVeileder(veilederIdent: String, personident: PersonIdent): Int {
+    var updatedRows: Int
+    this.connection.use { connection ->
+        updatedRows = connection.prepareStatement(queryUpdatePersonOversiktStatusVeileder).use {
+            it.setString(1, veilederIdent)
+            it.setString(2, personident.value)
+            it.executeUpdate()
+        }.also {
+            connection.commit()
+        }
+    }
+    return updatedRows
+}
+
+const val queryDeletePersonOversiktStatusFnr =
+    """
+        DELETE FROM PERSON_OVERSIKT_STATUS
+        WHERE fnr = ?
+    """
+
+fun DatabaseInterface.queryDeletePersonOversiktStatusFnr(personident: String): Int {
+    var deletedRows: Int
+    this.connection.use { connection ->
+        deletedRows = connection.prepareStatement(queryDeletePersonOversiktStatusFnr).use {
+            it.setString(1, personident)
+            it.executeUpdate()
+        }.also {
+            connection.commit()
+        }
+    }
+    return deletedRows
+}


### PR DESCRIPTION
I de tilfellene vi har den nye aktive identen allerede i databasen ved gjennomlesning av topic, får vi en feil på fnr-constraint. Løsningen er å heller slette gammel rad enn å overskrive fnr for den raden. Samtidig ønsker vi å kopiere over verdi for tildelt veileder fra gammel til ny rad dersom den mangler for den nye identen.