### PR TITLE
Handle different types of personidenter from kafkatopic

### DIFF
--- a/src/main/kotlin/no/nav/syfo/pdlpersonhendelse/PdlPersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdlpersonhendelse/PdlPersonhendelseService.kt
@@ -15,9 +15,13 @@ class PdlPersonhendelseService(
             personhendelse.personidenter
                 .mapNotNull { personIdent ->
                     try {
-                        PersonIdent(personIdent)
+                        if (personIdent.isNullOrEmpty() || personIdent.length == 13) {
+                            null
+                        } else {
+                            PersonIdent(personIdent)
+                        }
                     } catch (ex: IllegalArgumentException) {
-                        log.error("Error on personident for Personhendelse", ex)
+                        log.warn("Invalid personident for Personhendelse", ex)
                         null
                     }
                 }


### PR DESCRIPTION
Så i dev at veldig mange havnet i catch-blokka, og det er kanskje å anta at dette er mer normal oppførsel enn først antatt. Kan derfor endre logging fra error til warning, og så ta en dobbeltsjekk på at ikke innholdet i lista er null. Dette er Java-klasser så litt vanskelig å vite når vi får platform-typer.

I tillegg så virker det som at det kommer mye aktørIDer her (som er 13 siffer langt), så filterer ut de også.