### PR TITLE
Compensate for skipped Kafka-records

### DIFF
--- a/src/main/resources/db/migration/V13_3__repair_motebehov.sql
+++ b/src/main/resources/db/migration/V13_3__repair_motebehov.sql
@@ -1,0 +1,17 @@
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = 'f04bf481-2d61-43f5-a2c6-844869ecb929';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = '62b8de51-83f2-4eb4-8ad3-863499b4c168';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = 'cb7af729-0daa-4523-b426-04731379ce5f';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = '8d0cd105-c908-4e10-9fc1-ab5e9fc0b046';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = 'd69e5c5d-4eb7-4aa6-9b06-d9e83eda6640';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = '877336f6-b2ea-45e2-9604-dd0776904522';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = '26d6fdf2-c7bd-4da7-a75a-161f21785de7';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = '257d9269-3b03-455e-b042-ad6263f0eb48';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=FALSE WHERE uuid = '8aa7a632-7d1a-4ed3-b535-58d5da2e5841';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = '49f2bd1e-481b-426f-bb96-7b803ea47ed7';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = 'af977729-ed24-42b6-af14-73d8dd811610';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = '73f91e7a-7e9f-41d3-a40f-c3f1b3c64467';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = 'fc8b52d2-90a8-4973-a229-924195e86864';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = 'ca035bf4-dc20-4d44-ae98-8f2cd6bd16f8';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = '3b3b1741-df4b-4d69-ab1d-23cfae185fa1';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = 'f0f41a8e-8b13-4adf-af4a-b59d2ba8919f';
+UPDATE person_oversikt_status SET motebehov_ubehandlet=TRUE WHERE uuid = 'a93e9a55-3265-45ec-b2fe-fa3120ad586c';


### PR DESCRIPTION
Var litt for raske med forrige PR: siden esyfo merget sine tilpasninger først ble det noen minutter der vi tok i mot MOTEBEHOV_SVAR_MOTTATT og MOTEBEHOV_SVAR_BEHANDLET fra ny topic uten å behandle dem riktig (siden tilpasningene for å gjøre det lå i vår pull request som ble merget etterpå). Burde delt våre tilpasninger i to PR'er.

Vi har funnet igjen de Kafka-record'ene som ble lest uten at noe ble oppdatert i databasen, og laget et db-script som setter motebehov_ubehandlet til false for forekomstene av MOTEBEHOV_SVAR_BEHANDLET og til true for forekomstene av MOTEBEHOV_SVAR_MOTTATT.