### PR TITLE
Return aktivitetskrav even if it's from previous tilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -40,10 +40,7 @@ fun PersonOversiktStatus.isDialogmotekandidat() =
         dialogmotekandidatGeneratedAt.toLocalDateOslo().isBeforeOrEqual(LocalDate.now().minusDays(7))
 
 fun PersonOversiktStatus.isActiveAktivitetskrav() =
-    (aktivitetskrav == AktivitetskravStatus.NY || aktivitetskrav == AktivitetskravStatus.AVVENT) &&
-        latestOppfolgingstilfelle != null &&
-        aktivitetskravStoppunkt != null &&
-        aktivitetskravStoppunkt.isAfter(latestOppfolgingstilfelle.oppfolgingstilfelleStart)
+    aktivitetskrav == AktivitetskravStatus.NY || aktivitetskrav == AktivitetskravStatus.AVVENT
 
 data class Oppfolgingstilfelle(
     val updatedAt: OffsetDateTime,


### PR DESCRIPTION
Dette reverter i praksis #213

Vi fant ut at det er best om oppgaven består, og så får veileder vurdere selv om tilfellet egentlig er utdatert (da må det også gjøres en endring i syfomodiaperson).
Hvis en innbygger kommer så langt at de skal vurderes for aktivitetskrav, setter vi det gamle til automatisk_oppfylt e.l.