### PR TITLE
Reduce poll size

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/KafkaAktivitetskravVurderingTask.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/KafkaAktivitetskravVurderingTask.kt
@@ -21,7 +21,7 @@ fun launchKafkaTaskAktivitetskravVurdering(
     )
     val consumerProperties = Properties().apply {
         putAll(kafkaAivenConsumerConfig(kafkaEnvironment = kafkaEnvironment))
-        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "10"
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAktivitetskravVurderingDeserializer::class.java
     }
 

--- a/src/main/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/KafkaAktivitetskravVurderingTask.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/KafkaAktivitetskravVurderingTask.kt
@@ -21,6 +21,7 @@ fun launchKafkaTaskAktivitetskravVurdering(
     )
     val consumerProperties = Properties().apply {
         putAll(kafkaAivenConsumerConfig(kafkaEnvironment = kafkaEnvironment))
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAktivitetskravVurderingDeserializer::class.java
     }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonTask.kt
@@ -22,6 +22,7 @@ fun launchKafkaTaskOppfolgingstilfellePerson(
     )
     val consumerProperties = Properties().apply {
         putAll(kafkaAivenConsumerConfig(kafkaEnvironment = kafkaEnvironment))
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "10"
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
             KafkaOppfolgingstilfellePersonDeserializer::class.java.canonicalName
     }


### PR DESCRIPTION
Vi får mange db-konflikter nå og antar at det skyldes at oppfølgingstilfelle og aktivitetskrav for samme person leses samtidig fra Kafka. Ved å redusere poll-størrelse vil vi commit'e oftere og redusere sannsynligheten for slike konflikter. 