### PR TITLE
Skip processing of not-updated identhendelser in PDL

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -91,9 +91,5 @@ spec:
       value: "dev-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.dev-fss-pub.nais.io"
-    - name: TOGGLE_KAFKA_AKTIVITETSKRAV_VURDERING_PROCESSING_ENABLED
-      value: "true"
-    - name: TOGGLE_KAFKA_IDENTHENDELSE_UPDATES_ENABLED
-      value: "true"
     - name: AKTIVITETSKRAV_TEST_VEILEDER
       value: "Z994235"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -92,9 +92,5 @@ spec:
       value: "prod-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.prod-fss-pub.nais.io"
-    - name: TOGGLE_KAFKA_AKTIVITETSKRAV_VURDERING_PROCESSING_ENABLED
-      value: "true"
-    - name: TOGGLE_KAFKA_IDENTHENDELSE_UPDATES_ENABLED
-      value: "false"
     - name: AKTIVITETSKRAV_TEST_VEILEDER
       value: "S108787"

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -39,8 +39,6 @@ data class Environment(
         aivenRegistryUser = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
         aivenRegistryPassword = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
     ),
-    val kafkaAktivitetskravVurderingProcessingEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_AKTIVITETSKRAV_VURDERING_PROCESSING_ENABLED").toBoolean(),
-    val kafkaIdenthendelseUpdatesEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_IDENTHENDELSE_UPDATES_ENABLED").toBoolean(),
 
     val clients: ClientsEnvironment = ClientsEnvironment(
         ereg = ClientEnvironment(

--- a/src/main/kotlin/no/nav/syfo/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/KafkaModule.kt
@@ -33,20 +33,17 @@ fun launchKafkaModule(
         kafkaEnvironment = environment.kafka,
     )
 
-    if (environment.kafkaAktivitetskravVurderingProcessingEnabled) {
-        launchKafkaTaskAktivitetskravVurdering(
-            applicationState = applicationState,
-            kafkaEnvironment = environment.kafka,
-        )
-    }
+    launchKafkaTaskAktivitetskravVurdering(
+        applicationState = applicationState,
+        kafkaEnvironment = environment.kafka,
+    )
 
-    if (environment.kafkaIdenthendelseUpdatesEnabled) {
-        launchKafkaTaskIdenthendelse(
-            applicationState = applicationState,
-            environment = environment,
-            azureAdClient = azureAdClient,
-        )
-    }
+    launchKafkaTaskIdenthendelse(
+        applicationState = applicationState,
+        environment = environment,
+        azureAdClient = azureAdClient,
+    )
+
     launchKafkaTaskPersonhendelse(
         applicationState = applicationState,
         environment = environment,

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
@@ -105,6 +105,7 @@ fun DatabaseInterface.hentBrukereTilknyttetVeileder(veileder: String): List<Veil
 fun ResultSet.toPPersonOversiktStatus(): PPersonOversiktStatus =
     PPersonOversiktStatus(
         id = getInt("id"),
+        uuid = getString("uuid").let { UUID.fromString(it) },
         veilederIdent = getString("tildelt_veileder"),
         fnr = getString("fnr"),
         navn = getString("name"),

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PPersonOversiktStatus.kt
@@ -7,6 +7,7 @@ import java.util.*
 
 data class PPersonOversiktStatus(
     val veilederIdent: String?,
+    val uuid: UUID,
     val fnr: String,
     val navn: String?,
     val id: Int,

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -13,7 +13,6 @@ import no.nav.syfo.testutil.ExternalMockEnvironment
 import no.nav.syfo.testutil.UserConstants
 import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.generator.generateKafkaIdenthendelseDTO
-import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -60,8 +59,8 @@ object IdenthendelseServiceSpek : Spek({
                     }
 
                     // Check that person with old/current personident exist in db before update
-                    val currentPersonOversiktStatus = database.getPersonOversiktStatusList(oldIdent.value)
-                    currentPersonOversiktStatus.size shouldBeEqualTo 1
+                    val oldPersonOversiktStatus = database.getPersonOversiktStatusList(oldIdent.value)
+                    oldPersonOversiktStatus.size shouldBeEqualTo 1
 
                     runBlocking {
                         identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
@@ -70,10 +69,7 @@ object IdenthendelseServiceSpek : Spek({
                     // Check that person with new personident exist in db after update
                     val updatedPersonOversiktStatus = database.getPersonOversiktStatusList(newIdent.value)
                     updatedPersonOversiktStatus.size shouldBeEqualTo 1
-
-                    // Check that person with old personident do not exist in db after update
-                    val oldPersonOversiktStatus = database.getPersonOversiktStatusList(oldIdent.value)
-                    oldPersonOversiktStatus.size shouldBeEqualTo 0
+                    updatedPersonOversiktStatus.first().uuid shouldBeEqualTo oldPersonOversiktStatus.first().uuid
                 }
 
                 it("Skal ikke oppdatere database når person ikke finnes i databasen") {
@@ -154,14 +150,40 @@ object IdenthendelseServiceSpek : Spek({
             }
 
             describe("Unhappy path") {
-                it("Skal kaste feil hvis PDL ikke har oppdatert identen") {
+//                it("Skal kaste feil hvis PDL ikke har oppdatert identen") {
+//                    val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(
+//                        personident = PersonIdent(UserConstants.ARBEIDSTAKER_3_FNR),
+//                        hasOldPersonident = true,
+//                    )
+//                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
+//
+//                    // Populate database with new PersonOversiktStatus using old ident for person
+//                    val newPersonOversiktStatus = PersonOversiktStatus(fnr = oldIdent.value)
+//                    database.connection.use { connection ->
+//                        connection.createPersonOversiktStatus(
+//                            commit = true,
+//                            personOversiktStatus = newPersonOversiktStatus,
+//                        )
+//                    }
+//
+//                    // Check that person with old/current personident exist in db before update
+//                    val currentPersonOversiktStatus = database.getPersonOversiktStatusList(oldIdent.value)
+//                    currentPersonOversiktStatus.size shouldBeEqualTo 1
+//
+//                    runBlocking {
+//                        assertFailsWith(IllegalStateException::class) {
+//                            identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
+//                        }
+//                    }
+//                }
+
+                it("Skal hoppe over record hvis PDL ikke har oppdatert identen") {
                     val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(
                         personident = PersonIdent(UserConstants.ARBEIDSTAKER_3_FNR),
                         hasOldPersonident = true,
                     )
                     val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
 
-                    // Populate database with new PersonOversiktStatus using old ident for person
                     val newPersonOversiktStatus = PersonOversiktStatus(fnr = oldIdent.value)
                     database.connection.use { connection ->
                         connection.createPersonOversiktStatus(
@@ -170,15 +192,14 @@ object IdenthendelseServiceSpek : Spek({
                         )
                     }
 
-                    // Check that person with old/current personident exist in db before update
-                    val currentPersonOversiktStatus = database.getPersonOversiktStatusList(oldIdent.value)
-                    currentPersonOversiktStatus.size shouldBeEqualTo 1
+                    database.getPersonOversiktStatusList(oldIdent.value).size shouldBeEqualTo 1
 
                     runBlocking {
-                        assertFailsWith(IllegalStateException::class) {
-                            identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
-                        }
+                        identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
                     }
+
+                    database.getPersonOversiktStatusList(oldIdent.value).size shouldBeEqualTo 1
+                    database.getPersonOversiktStatusList(kafkaIdenthendelseDTO.getActivePersonident()!!.value).size shouldBeEqualTo 0
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -65,8 +65,6 @@ fun testEnvironment(
         port = 6376,
         secret = "password",
     ),
-    kafkaAktivitetskravVurderingProcessingEnabled = true,
-    kafkaIdenthendelseUpdatesEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/PPersonOversiktStatusGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/PPersonOversiktStatusGenerator.kt
@@ -2,10 +2,12 @@ package no.nav.syfo.testutil.generator
 
 import no.nav.syfo.personstatus.domain.PPersonOversiktStatus
 import no.nav.syfo.testutil.UserConstants
+import java.util.*
 
 fun generatePPersonOversiktStatus() = PPersonOversiktStatus(
     veilederIdent = null,
     fnr = UserConstants.ARBEIDSTAKER_FNR,
+    uuid = UUID.randomUUID(),
     navn = null,
     id = 1,
     enhet = null,


### PR DESCRIPTION
Geir og jeg diskuterte dette, vi endte opp med å prøve følgende:

1. Dersom det feiler mot PDL nå når vi leser historiske endringer, så prøver vi å logge `uuid`en til den identen i vår database, slik at vi kan undersøke denne med pdl for å finne hva som er galt
2. Når vi er ferdig med å lese historiske endringer, bytter vi til å prosessere som før igjen
3. Dersom det ble veldig mange uuider å følge opp manuelt i loggen, må vi se på om logikken vår er feil. Det er uansett ikke krise om vi da må lese topicet på nytt, eller om vi bare fikk oppdatert deler av identene. 

Jeg har kommentert ut litt kode per nå, og mulig noen av metodenenavnene kanskje ikke gir like mye mening, men planen er altså å bytte tilbake igjen når vi har fått lest gjennom de historiske endringene og er over på å konsumere "nye" identhendelser.

Noe å legge til, Geir?