### PR TITLE
Retry via unsubscribe and delay on error in identhendelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/identhendelse/kafka/IdenthendelseConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/kafka/IdenthendelseConsumerService.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.identhendelse.kafka
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.identhendelse.IdenthendelseService
 import no.nav.syfo.kafka.KafkaConsumerService
 import no.nav.syfo.metric.COUNT_KAFKA_CONSUMER_PDL_AKTOR_TOMBSTONE
@@ -9,6 +11,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class IdenthendelseConsumerService(
     private val identhendelseService: IdenthendelseService,
@@ -16,21 +19,30 @@ class IdenthendelseConsumerService(
     override val pollDurationInMillis: Long = 1000
 
     override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
-        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
-        if (records.count() > 0) {
-            records.forEach { record ->
-                if (record.value() != null) {
-                    identhendelseService.handleIdenthendelse(record.value().toKafkaIdenthendelseDTO())
-                } else {
-                    log.warn("Identhendelse: Value of ConsumerRecord from topic $PDL_AKTOR_TOPIC is null, probably due to a tombstone. Contact the owner of the topic if an error is suspected")
-                    COUNT_KAFKA_CONSUMER_PDL_AKTOR_TOMBSTONE.increment()
+        runBlocking {
+            try {
+                val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+                if (records.count() > 0) {
+                    records.forEach { record ->
+                        if (record.value() != null) {
+                            identhendelseService.handleIdenthendelse(record.value().toKafkaIdenthendelseDTO())
+                        } else {
+                            log.warn("Identhendelse: Value of ConsumerRecord from topic $PDL_AKTOR_TOPIC is null, probably due to a tombstone. Contact the owner of the topic if an error is suspected")
+                            COUNT_KAFKA_CONSUMER_PDL_AKTOR_TOMBSTONE.increment()
+                        }
+                    }
+                    kafkaConsumer.commitSync()
                 }
+            } catch (ex: Exception) {
+                log.error("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry")
+                kafkaConsumer.unsubscribe()
+                delay(DELAY_ON_ERROR_SECONDS.seconds)
             }
-            kafkaConsumer.commitSync()
         }
     }
 
     companion object {
+        private const val DELAY_ON_ERROR_SECONDS = 60L
         private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.identhendelse")
     }
 }

--- a/src/main/kotlin/no/nav/syfo/kafka/KafkaTask.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/KafkaTask.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.kafka
 
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.backgroundtask.launchBackgroundTask
+import no.nav.syfo.identhendelse.kafka.PDL_AKTOR_TOPIC
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import java.util.*
 
@@ -20,6 +21,9 @@ inline fun <reified ConsumerRecordValue> launchKafkaTask(
         )
 
         while (applicationState.ready) {
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(PDL_AKTOR_TOPIC))
+            }
             kafkaConsumerService.pollAndProcessRecords(kafkaConsumer)
         }
     }


### PR DESCRIPTION
Dette blir mer likt som i de andre appene, og _helt likt_ som i `isaktivitetskrav` der `pollAndProcessRecords`-funksjonen ikke er en suspend, men har en `runBlocking`.