### PR TITLE
Include aktivitetskrav in cronjob queries

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
@@ -57,7 +57,12 @@ const val queryGetPersonerWithOppgaveAndOldEnhet =
     """
     SELECT fnr, tildelt_enhet
     FROM PERSON_OVERSIKT_STATUS
-    WHERE (motebehov_ubehandlet = 't' OR oppfolgingsplan_lps_bistand_ubehandlet = 't' OR dialogmotekandidat = 't' OR dialogmotesvar_ubehandlet = 't')
+    WHERE (motebehov_ubehandlet = 't' 
+        OR oppfolgingsplan_lps_bistand_ubehandlet = 't' 
+        OR dialogmotekandidat = 't' 
+        OR dialogmotesvar_ubehandlet = 't'
+        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT') AND aktivitetskrav_stoppunkt > '2023-02-01')
+        )
     AND (tildelt_enhet_updated_at IS NULL OR tildelt_enhet_updated_at <= NOW() - INTERVAL '24 HOURS')
     ORDER BY tildelt_enhet_updated_at ASC
     LIMIT 2000

--- a/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
@@ -31,7 +31,12 @@ const val queryPersonOppfolgingstilfelleVirksomhetNoVirksomhetsnavnList =
     SELECT PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET.id,virksomhetsnummer
     FROM PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET INNER JOIN PERSON_OVERSIKT_STATUS ON PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET.person_oversikt_status_id = PERSON_OVERSIKT_STATUS.id
     WHERE virksomhetsnavn IS NULL
-    AND (motebehov_ubehandlet = 't' OR oppfolgingsplan_lps_bistand_ubehandlet = 't' OR dialogmotekandidat = 't' OR dialogmotesvar_ubehandlet = 't')
+    AND (motebehov_ubehandlet = 't' 
+        OR oppfolgingsplan_lps_bistand_ubehandlet = 't' 
+        OR dialogmotekandidat = 't' 
+        OR dialogmotesvar_ubehandlet = 't' 
+        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT') AND aktivitetskrav_stoppunkt > '2023-02-01')
+        )
     ORDER BY PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET.created_at ASC
     LIMIT 1000
     """

--- a/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
@@ -5,6 +5,8 @@ import io.ktor.util.*
 import io.mockk.clearMocks
 import io.mockk.every
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
+import no.nav.syfo.aktivitetskravvurdering.persistAktivitetskrav
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.personoppgavehendelse.kafka.KPersonoppgavehendelse
 import no.nav.syfo.personoppgavehendelse.kafka.PersonoppgavehendelseService
@@ -25,8 +27,7 @@ import org.amshove.kluent.*
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.time.Duration
-import java.time.OffsetDateTime
+import java.time.*
 import java.util.UUID
 
 @InternalAPI
@@ -303,6 +304,45 @@ object PersonBehandlendeEnhetCronjobSpek : Spek({
                         result.failed shouldBeEqualTo 0
                         result.updated shouldBeEqualTo 0
                     }
+                }
+
+                it("updates Enhet if active aktivitetskrav") {
+                    val aktivitetskrav = generateAktivitetskrav(
+                        personIdent = personIdentDefault,
+                        status = AktivitetskravStatus.NY,
+                        stoppunktAfterCutoff = true,
+                    )
+                    database.connection.use { connection ->
+                        persistAktivitetskrav(
+                            connection = connection,
+                            aktivitetskrav = aktivitetskrav,
+                        )
+                        connection.commit()
+                    }
+
+                    var pPersonOversiktStatusList = database.getPersonOversiktStatusList(fnr = personIdentDefault.value)
+
+                    pPersonOversiktStatusList.size shouldBeEqualTo 1
+
+                    var pPersonOversiktStatus = pPersonOversiktStatusList.first()
+                    pPersonOversiktStatus.enhet.shouldBeNull()
+                    pPersonOversiktStatus.tildeltEnhetUpdatedAt.shouldBeNull()
+                    pPersonOversiktStatus.aktivitetskrav.shouldNotBeNull()
+
+                    runBlocking {
+                        val result = personBehandlendeEnhetCronjob.runJob()
+
+                        result.failed shouldBeEqualTo 0
+                        result.updated shouldBeEqualTo 1
+                    }
+
+                    pPersonOversiktStatusList = database.getPersonOversiktStatusList(fnr = personIdentDefault.value)
+                    pPersonOversiktStatusList.size shouldBeEqualTo 1
+
+                    pPersonOversiktStatus = pPersonOversiktStatusList.first()
+
+                    pPersonOversiktStatus.enhet.shouldNotBeNull()
+                    pPersonOversiktStatus.tildeltEnhetUpdatedAt.shouldNotBeNull()
                 }
 
                 it("should update Enhet and remove Veileder of existing PersonOversiktStatus with no Enhet if oppfolgingsplanLPSBistandUbehandlet is true") {

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/AktivitetskravGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/AktivitetskravGenerator.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.testutil.generator
+
+import no.nav.syfo.aktivitetskravvurdering.domain.Aktivitetskrav
+import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
+import no.nav.syfo.domain.PersonIdent
+import java.time.*
+
+// Samme dato som i queries
+private val aktivitetskravStoppunktCutoff = LocalDate.of(2023, Month.FEBRUARY, 1)
+
+fun generateAktivitetskrav(
+    personIdent: PersonIdent,
+    status: AktivitetskravStatus,
+    stoppunktAfterCutoff: Boolean,
+    sistVurdert: OffsetDateTime? = null,
+): Aktivitetskrav {
+    val stoppunkt =
+        if (stoppunktAfterCutoff) aktivitetskravStoppunktCutoff.plusDays(1) else aktivitetskravStoppunktCutoff.minusDays(
+            1
+        )
+    return Aktivitetskrav(
+        personIdent = personIdent,
+        status = status,
+        sistVurdert = sistVurdert,
+        stoppunkt = stoppunkt,
+    )
+}


### PR DESCRIPTION
Sjekket i prod-databasen og det ser ut til å bli cirka 20k rader med aktivitetskrav som må oppdateres for hver cronjob. Tenker det bør gå greit å starte i ettermiddag f.eks.