### PR TITLE
Close open motebehov that are closed in syfomotebehov

### DIFF
--- a/src/main/resources/db/migration/V14_3__close_motebehov.sql
+++ b/src/main/resources/db/migration/V14_3__close_motebehov.sql
@@ -1,0 +1,15 @@
+UPDATE person_oversikt_status
+SET motebehov_ubehandlet = FALSE
+WHERE uuid IN (
+'dbf7c45f-0ddc-4408-9003-0fe2019faad0',
+'610d46cd-3d3b-43d1-accb-b89cf4d1ea3d',
+'447f5c6e-b312-467e-a0ff-0dbddd739438',
+'5d8d0ec7-7f07-4ca9-aa4a-a748282ccd06',
+'0d807dd8-e655-4f2d-af2f-1c2784f4f123',
+'ad44db12-e287-4a1f-92f0-6dbabd0aba69',
+'3ce7f60f-1cb0-49b7-b24b-64b26e7709c7',
+'4f154e54-e53d-420b-a930-ec8b45a84cb8',
+'4e28c98a-a591-4b2a-abd5-6733eddc94bb',
+'ede81dc3-2cb1-4a5e-a0dd-1a55d37a0175',
+'fba66d70-12b9-40e2-a29d-903d0b4550f7',
+'afbca1ee-d148-4b7f-b932-2097623d0fac');


### PR DESCRIPTION
We don't know why these motebehov_ubehandlet are true. 4 of the users don't even exist in syfomotebehov. Others haven't been sick in years. Theories that have been checked out:

* Changed identities: PDL only had one id on the users we checked
* Saving in syfomotebehov failed, but the entry still ended up on Kafka: not possible
* Scripts/code that wrongfully deleted entries i syfomotebehov: nothing that have been committed

The list we're setting to false here is based on a query made across the databases of the two apps, it contains all the current erronous true ubehandlet_syfomotebehov. The plan now is to wait for new entries. It will hopefully be easier to debug the error when it happens in a more current state of the environment.