### PR TITLE
Close open motebehov that are closed in syfomotebehov

### DIFF
--- a/src/main/resources/db/migration/V14_8__close_motebehov.sql
+++ b/src/main/resources/db/migration/V14_8__close_motebehov.sql
@@ -1,0 +1,6 @@
+UPDATE person_oversikt_status
+SET motebehov_ubehandlet = FALSE
+WHERE uuid IN (
+'008a98fb-040b-4e6e-9206-c3f15f6fece5',
+'52642378-8136-482d-9b0e-8edea95ab6cc'
+);


### PR DESCRIPTION
Set true motebehov to false on users with no motebehov in syfomotebehov.

We still don't know why this happens. These persons have entries in syfomotebehov, but none that lead to an update of syfooversiktsrv.