### PR TITLE
Filter out ChannelWriteException from log

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ object Versions {
     const val hikari = "5.0.1"
     const val isdialogmoteSchema = "1.0.5"
     const val jacksonDataType = "2.14.2"
+    const val janino = "3.1.9"
     const val jedis = "4.3.2"
     const val kafka = "3.4.0"
     const val kafkaEmbedded = "3.2.3"
@@ -67,6 +68,7 @@ dependencies {
     // Logging
     implementation("ch.qos.logback:logback-classic:${Versions.logback}")
     implementation("net.logstash.logback:logstash-logback-encoder:${Versions.logstashEncoder}")
+    implementation("org.codehaus.janino:janino:${Versions.janino}")
 
     // Metrics and Prometheus
     implementation("io.ktor:ktor-server-metrics-micrometer:${Versions.ktor}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ object Versions {
     const val hikari = "5.0.1"
     const val isdialogmoteSchema = "1.0.5"
     const val jacksonDataType = "2.14.2"
-    const val janino = "3.1.9"
     const val jedis = "4.3.2"
     const val kafka = "3.4.0"
     const val kafkaEmbedded = "3.2.3"
@@ -30,7 +29,7 @@ object Versions {
 }
 
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm") version "1.8.20"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
     id("com.github.davidmc24.gradle.plugin.avro") version "1.7.0"
@@ -68,7 +67,6 @@ dependencies {
     // Logging
     implementation("ch.qos.logback:logback-classic:${Versions.logback}")
     implementation("net.logstash.logback:logstash-logback-encoder:${Versions.logstashEncoder}")
-    implementation("org.codehaus.janino:janino:${Versions.janino}")
 
     // Metrics and Prometheus
     implementation("io.ktor:ktor-server-metrics-micrometer:${Versions.ktor}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,8 @@ object Versions {
 plugins {
     kotlin("jvm") version "1.8.22"
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
-    id("com.github.davidmc24.gradle.plugin.avro") version "1.7.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.4.0"
+    id("com.github.davidmc24.gradle.plugin.avro") version "1.7.1"
 }
 
 val githubUser: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ object Versions {
 }
 
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.8.22"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
     id("com.github.davidmc24.gradle.plugin.avro") version "1.7.0"

--- a/src/main/kotlin/no/nav/syfo/application/api/authentication/ApiFeature.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/authentication/ApiFeature.kt
@@ -12,6 +12,7 @@ import io.ktor.server.plugins.callid.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
+import io.ktor.util.cio.ChannelWriteException
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.metric.METRICS_REGISTRY
@@ -89,7 +90,11 @@ fun Application.installStatusPages() {
             val callId = call.getCallId()
             val consumerId = call.getConsumerId()
             val exceptionMessage = "Caught exception, callId=$callId, consumerClientId=$consumerId"
-            call.application.log.error(exceptionMessage, cause)
+            if (cause is ChannelWriteException) {
+                call.application.log.warn(exceptionMessage, cause)
+            } else {
+                call.application.log.error(exceptionMessage, cause)
+            }
 
             var isUnexpectedException = false
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,15 +11,6 @@
                 </valueMask>
             </jsonGeneratorDecorator>
         </encoder>
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>
-                    return throwable instanceof io.ktor.util.cio.ChannelWriteException;
-                </expression>
-            </evaluator>
-            <OnMismatch>NEUTRAL</OnMismatch>
-            <OnMatch>DENY</OnMatch>
-        </filter>
     </appender>
 
     <logger name="no.nav" level="INFO"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,6 +11,15 @@
                 </valueMask>
             </jsonGeneratorDecorator>
         </encoder>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>
+                    return throwable instanceof io.ktor.util.cio.ChannelWriteException;
+                </expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
     </appender>
 
     <logger name="no.nav" level="INFO"/>


### PR DESCRIPTION
Hvis hypotesen om at ChannelWriteException-feilene skyldes at klienten har navigert vekk fra siden, så kan vi likegodt sørge for at disse feilene ikke logges.

Litt usikker på om dette gjør susen, må nesten forsøkes i praksis.