### PR TITLE
Close oppgave for oppfolgingsplanlps

### DIFF
--- a/src/main/resources/db/migration/V15_0__close_oppfolgingsplan_lps.sql
+++ b/src/main/resources/db/migration/V15_0__close_oppfolgingsplan_lps.sql
@@ -1,0 +1,3 @@
+UPDATE person_oversikt_status
+SET oppfolgingsplan_lps_bistand_ubehandlet = FALSE
+WHERE uuid = 'b6527213-04a1-47a3-af38-e18ad183ac60';


### PR DESCRIPTION
The original oppfolgingsplan was deleted, so it's not possible to close this manually. Last oppgave of that type is closed in ispersonoppgave here https://github.com/navikt/ispersonoppgave/pull/146 This is needed as well because ispersonoppgave doesn't automatically send event on kafka when LPS-oppgave is closed with flyway script.

https://jira.adeo.no/browse/FAGSYSTEM-284794