### PR TITLE
IS-1652: Use correct topic when resubscribing

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/KafkaTask.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/KafkaTask.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.kafka
 
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.backgroundtask.launchBackgroundTask
-import no.nav.syfo.identhendelse.kafka.PDL_AKTOR_TOPIC
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import java.util.*
 
@@ -22,7 +21,7 @@ inline fun <reified ConsumerRecordValue> launchKafkaTask(
 
         while (applicationState.ready) {
             if (kafkaConsumer.subscription().isEmpty()) {
-                kafkaConsumer.subscribe(listOf(PDL_AKTOR_TOPIC))
+                kafkaConsumer.subscribe(listOf(topic))
             }
             kafkaConsumerService.pollAndProcessRecords(kafkaConsumer)
         }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Her har det sneket seg inn en bug mens jeg jobbet med identhendelser. Trodde sikkert at `launchKafkaTask` var spesifikk og ikke generell, og hardkodet derfor topicet. Heldigvis gjør vi vel ingen unsubscribe noen andre steder enn i identhendelse-consumeren, men hvis man på sikt vil gjøre noe sånt, så er det dumt om den kobler seg på feil topic slik den gamle koden tillatter.