### PR TITLE
IS-1671: Increase behandlende enhet cronjob freq

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -99,5 +99,5 @@ spec:
     # Bruk samme dato i enhetens-oversikt-query og index
     - name: ARENA_CUTOFF
       value: "2023-03-10"
-    - name: IS_HUSKELAPP_CONSUMER_ENABLED
-      value: "true"
+    - name: CRONJOB_BEHANDLENDE_ENHET_INTERVAL_DELAY_MINUTES
+      value: "2"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -101,5 +101,5 @@ spec:
     # Bruk samme dato i enhetens-oversikt-query og index
     - name: ARENA_CUTOFF
       value: "2023-03-10"
-    - name: IS_HUSKELAPP_CONSUMER_ENABLED
-      value: "true"
+    - name: CRONJOB_BEHANDLENDE_ENHET_INTERVAL_DELAY_MINUTES
+      value: "15"

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -71,7 +71,7 @@ data class Environment(
         secret = getEnvVar("REDIS_PASSWORD"),
     ),
 
-    val isHuskelappConsumerEnabled: Boolean = getEnvVar("IS_HUSKELAPP_CONSUMER_ENABLED").toBoolean()
+    val cronjobBehandlendeEnhetIntervalDelayMinutes: Long = getEnvVar("CRONJOB_BEHANDLENDE_ENHET_INTERVAL_DELAY_MINUTES").toLong(),
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -47,6 +47,7 @@ fun launchCronjobModule(
     )
     val personBehandlendeEnhetCronjob = PersonBehandlendeEnhetCronjob(
         personBehandlendeEnhetService = personBehandlendeEnhetService,
+        intervalDelayMinutes = environment.cronjobBehandlendeEnhetIntervalDelayMinutes,
     )
 
     val reaperService = ReaperService(

--- a/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjob.kt
@@ -7,10 +7,10 @@ import org.slf4j.LoggerFactory
 
 class PersonBehandlendeEnhetCronjob(
     private val personBehandlendeEnhetService: PersonBehandlendeEnhetService,
+    override val intervalDelayMinutes: Long,
 ) : Cronjob {
 
     override val initialDelayMinutes: Long = 2
-    override val intervalDelayMinutes: Long = 60L
 
     override suspend fun run() {
         runJob()

--- a/src/main/kotlin/no/nav/syfo/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/KafkaModule.kt
@@ -53,10 +53,8 @@ fun launchKafkaModule(
         environment = environment,
     )
 
-    if (environment.isHuskelappConsumerEnabled) {
-        launchHuskelappConsumer(
-            applicationState = applicationState,
-            kafkaEnvironment = environment.kafka,
-        )
-    }
+    launchHuskelappConsumer(
+        applicationState = applicationState,
+        kafkaEnvironment = environment.kafka,
+    )
 }

--- a/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
@@ -42,6 +42,7 @@ class InternalMockEnvironment private constructor() {
     )
     val personBehandlendeEnhetCronjob = PersonBehandlendeEnhetCronjob(
         personBehandlendeEnhetService = personBehandlendeEnhetService,
+        intervalDelayMinutes = environment.cronjobBehandlendeEnhetIntervalDelayMinutes,
     )
 
     private val personOppfolgingstilfelleVirksomhetsnavnService = PersonOppfolgingstilfelleVirksomhetsnavnService(

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -74,7 +74,7 @@ fun testEnvironment(
         port = 6376,
         secret = "password",
     ),
-    isHuskelappConsumerEnabled = true,
+    cronjobBehandlendeEnhetIntervalDelayMinutes = 5,
 )
 
 fun testAppState() = ApplicationState(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Bakgrunn: Personer som er nye i oversikten (f.eks. pga huskelapp) må få satt tildelt enhet for at de skal dukke opp i oversikten. Prøver derfor å kjøre cronjobben som setter/oppdaterer dette litt oftere. 
Ser ut til at den bruker opp mot 10 minutter på å kjøre i prod, så tenker hvert 15. minutt skal gå greit. Setter den til å kjøre enda oftere i dev.
