### PR TITLE
IS-1686: Use new tilgangskontroll app

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -53,7 +53,6 @@ spec:
       rules:
         - application: syfobehandlendeenhet
         - application: syfooversiktsrv-redis
-        - application: syfo-tilgangskontroll
         - application: istilgangskontroll
   azure:
     application:
@@ -88,10 +87,6 @@ spec:
       value: "dev-gcp.teamsykefravr.syfobehandlendeenhet"
     - name: SYFOBEHANDLENDEENHET_URL
       value: "http://syfobehandlendeenhet"
-    - name: SYFOTILGANGSKONTROLL_CLIENT_ID
-      value: "dev-gcp.teamsykefravr.syfo-tilgangskontroll"
-    - name: SYFOTILGANGSKONTROLL_URL
-      value: "http://syfo-tilgangskontroll"
     - name: ISTILGANGSKONTROLL_CLIENT_ID
       value: "dev-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_HOST

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -54,7 +54,6 @@ spec:
       rules:
         - application: syfobehandlendeenhet
         - application: syfooversiktsrv-redis
-        - application: syfo-tilgangskontroll
         - application: istilgangskontroll
   azure:
     application:
@@ -90,10 +89,6 @@ spec:
       value: "prod-gcp.teamsykefravr.syfobehandlendeenhet"
     - name: SYFOBEHANDLENDEENHET_URL
       value: "http://syfobehandlendeenhet"
-    - name: SYFOTILGANGSKONTROLL_CLIENT_ID
-      value: "prod-gcp.teamsykefravr.syfo-tilgangskontroll"
-    - name: SYFOTILGANGSKONTROLL_URL
-      value: "http://syfo-tilgangskontroll"
     - name: ISTILGANGSKONTROLL_CLIENT_ID
       value: "prod-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_HOST

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -55,10 +55,6 @@ data class Environment(
             baseUrl = getEnvVar("SYFOBEHANDLENDEENHET_URL"),
             clientId = getEnvVar("SYFOBEHANDLENDEENHET_CLIENT_ID"),
         ),
-        syfotilgangskontroll = ClientEnvironment(
-            baseUrl = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
-            clientId = getEnvVar("SYFOTILGANGSKONTROLL_CLIENT_ID"),
-        ),
         istilgangskontroll = ClientEnvironment(
             baseUrl = getEnvVar("ISTILGANGSKONTROLL_HOST"),
             clientId = getEnvVar("ISTILGANGSKONTROLL_CLIENT_ID"),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -43,7 +43,6 @@ fun Application.apiModule(
 
     val tilgangskontrollConsumer = VeilederTilgangskontrollClient(
         azureAdClient = azureAdClient,
-        syfotilgangskontrollEnv = environment.clients.syfotilgangskontroll,
         istilgangskontrollEnv = environment.clients.istilgangskontroll,
     )
 

--- a/src/main/kotlin/no/nav/syfo/client/ClientEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ClientEnvironment.kt
@@ -4,7 +4,6 @@ data class ClientsEnvironment(
     val ereg: ClientEnvironment,
     val pdl: ClientEnvironment,
     val syfobehandlendeenhet: ClientEnvironment,
-    val syfotilgangskontroll: ClientEnvironment,
     val istilgangskontroll: ClientEnvironment,
 )
 

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -17,7 +17,6 @@ import java.util.UUID
 
 class VeilederTilgangskontrollClient(
     private val azureAdClient: AzureAdClient,
-    private val syfotilgangskontrollEnv: ClientEnvironment,
     private val istilgangskontrollEnv: ClientEnvironment
 ) {
     private val httpClient = httpClientDefault()
@@ -32,7 +31,7 @@ class VeilederTilgangskontrollClient(
         callId: String
     ): List<String>? {
         val oboToken = azureAdClient.getOnBehalfOfToken(
-            scopeClientId = syfotilgangskontrollEnv.clientId,
+            scopeClientId = istilgangskontrollEnv.clientId,
             token = token
         )?.accessToken
             ?: throw RuntimeException("Failed to request access to list of persons: Failed to get OBO token")
@@ -49,21 +48,22 @@ class VeilederTilgangskontrollClient(
                 setBody(personIdentNumberList)
             }
 
-            requestTimer.stop(HISTOGRAM_SYFOTILGANGSKONTROLL_PERSONER)
+            requestTimer.stop(HISTOGRAM_ISTILGANGSKONTROLL_PERSONER)
             COUNT_CALL_TILGANGSKONTROLL_PERSONS_SUCCESS.increment()
-            return response.body()
+
+            return response.body<List<String>>()
         } catch (e: ClientRequestException) {
             return if (e.response.status == HttpStatusCode.Forbidden) {
-                log.warn("Forbidden to request access to list of person from syfo-tilgangskontroll")
+                log.warn("Forbidden to request access to list of person from istilgangskontroll")
                 null
             } else {
                 COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL.increment()
-                log.error("Error while requesting access to list of person from syfo-tilgangskontroll: ${e.message}", e)
+                log.error("Error while requesting access to list of person from istilgangskontroll: ${e.message}", e)
                 null
             }
         } catch (e: ServerResponseException) {
             COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL.increment()
-            log.error("Error while requesting access to list of person from syfo-tilgangskontroll: ${e.message}", e)
+            log.error("Error while requesting access to list of person from istilgangskontroll: ${e.message}", e)
             return null
         }
     }
@@ -72,7 +72,7 @@ class VeilederTilgangskontrollClient(
         personIdentNumberList: List<String>,
     ): Boolean {
         val systemToken = azureAdClient.getSystemToken(
-            scopeClientId = syfotilgangskontrollEnv.clientId,
+            scopeClientId = istilgangskontrollEnv.clientId,
         )?.accessToken
             ?: throw RuntimeException("Failed to request preload of list of persons: Failed to get system token")
 
@@ -87,13 +87,13 @@ class VeilederTilgangskontrollClient(
             HttpStatusCode.OK == response.status
         } catch (e: ClientRequestException) {
             if (e.response.status == HttpStatusCode.Forbidden) {
-                log.warn("Forbidden to request preload of list of person from syfo-tilgangskontroll")
+                log.warn("Forbidden to request preload of list of person from istilgangskontroll")
             } else {
-                log.error("Error while requesting preload of list of person from syfo-tilgangskontroll: ${e.message}", e)
+                log.error("Error while requesting preload of list of person from istilgangskontroll: ${e.message}", e)
             }
             false
         } catch (e: ServerResponseException) {
-            log.error("Error while requesting preload of list of person from syfo-tilgangskontroll: ${e.message}", e)
+            log.error("Error while requesting preload of list of person from istilgangskontroll: ${e.message}", e)
             false
         }
     }
@@ -110,7 +110,7 @@ class VeilederTilgangskontrollClient(
 
         try {
             val requestTimer: Timer.Sample = Timer.start()
-            val url = getTilgangskontrollHost("$pathTilgangTilEnhetOBO/$enhet")
+            val url = getTilgangskontrollUrl("$pathTilgangTilEnhetOBO/$enhet")
             val response: HttpResponse = httpClient.get(url) {
                 header(HttpHeaders.Authorization, bearerHeader(oboToken))
                 header(NAV_CALL_ID_HEADER, callId)
@@ -130,12 +130,7 @@ class VeilederTilgangskontrollClient(
         }
     }
 
-    // TODO: delete this function when syfo-tilgangskontroll is no longer in use
     private fun getTilgangskontrollUrl(path: String): String {
-        return "${syfotilgangskontrollEnv.baseUrl}/syfo-tilgangskontroll/api/tilgang$path"
-    }
-
-    private fun getTilgangskontrollHost(path: String): String {
         return "${istilgangskontrollEnv.baseUrl}/api/tilgang$path"
     }
     companion object {

--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -59,7 +59,6 @@ fun launchCronjobModule(
 
     val tilgangskontrollClient = VeilederTilgangskontrollClient(
         azureAdClient = azureAdClient,
-        syfotilgangskontrollEnv = environment.clients.syfotilgangskontroll,
         istilgangskontrollEnv = environment.clients.istilgangskontroll,
     )
     val preloadCacheCronjob = PreloadCacheCronjob(

--- a/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
@@ -42,9 +42,8 @@ const val OVERSIKTHENDELSE_DIALOGMOTESVAR_BEHANDLET_BASE = "${METRICS_NS}_oversi
 const val OVERSIKTHENDELSE_DIALOGMOTESVAR_BEHANDLET_OPPDATER = "${OVERSIKTHENDELSE_DIALOGMOTESVAR_BEHANDLET_BASE}_oppdater_count"
 const val OVERSIKTHENDELSE_DIALOGMOTESVAR_BEHANDLET_FEILET = "${OVERSIKTHENDELSE_DIALOGMOTESVAR_BEHANDLET_BASE}_feilet_count"
 
-const val SYFOTILGANGSKONTROLL_HISTOGRAM_ENHET = "${METRICS_NS}_syfotilgangskontroll_histogram_enhet"
 const val ISTILGANGSKONTROLL_HISTOGRAM_ENHET = "${METRICS_NS}_istilgangskontroll_histogram_enhet"
-const val SYFOTILGANGSKONTROLL_HISTOGRAM_PERSONER = "${METRICS_NS}_syfotilgangskontroll_histogram_personer"
+const val ISTILGANGSKONTROLL_HISTOGRAM_PERSONER = "${METRICS_NS}_istilgangskontroll_histogram_personer"
 
 const val PERSONOVERSIKT_HISTOGRAM_ENHET = "${METRICS_NS}_personoversikt_histogram_enhet"
 
@@ -57,10 +56,10 @@ const val KAFKA_CONSUMER_PDL_PERSONHENDELSE_UPDATES = "${KAFKA_CONSUMER_PDL_PERS
 const val KAFKA_CONSUMER_PDL_PERSONHENDELSE_TOMBSTONE = "${KAFKA_CONSUMER_PDL_PERSONHENDELSE_BASE}_tombstone"
 
 val COUNT_CALL_TILGANGSKONTROLL_PERSONS_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_SUCCESS)
-    .description("Counts the number of successful calls to syfo-tilgangskontroll - persons")
+    .description("Counts the number of successful calls to tilgangskontroll - persons")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_FAIL)
-    .description("Counts the number of failed calls to syfo-tilgangskontroll - persons")
+    .description("Counts the number of failed calls to tilgangskontroll - persons")
     .register(METRICS_REGISTRY)
 
 val COUNT_PERSONOVERSIKTSTATUS_ENHET_HENTET: Counter = Counter.builder(PERSONOVERSIKTSTATUS_ENHET_HENTET)
@@ -147,12 +146,8 @@ val COUNT_KAFKA_CONSUMER_PDL_PERSONHENDELSE_TOMBSTONE: Counter =
         .description("Counts the number of tombstones received from topic - pdl.leesah-v1")
         .register(METRICS_REGISTRY)
 
-val HISTOGRAM_SYFOTILGANGSKONTROLL_PERSONER: Timer = Timer.builder(SYFOTILGANGSKONTROLL_HISTOGRAM_PERSONER)
-    .description("Measure the current time it takes to get a response from Syfotilgangskontroll - personer")
-    .register(METRICS_REGISTRY)
-
-val HISTOGRAM_SYFOTILGANGSKONTROLL_ENHET: Timer = Timer.builder(SYFOTILGANGSKONTROLL_HISTOGRAM_ENHET)
-    .description("Measure the current time it takes to get a response from Syfotilgangskontroll - enhet ")
+val HISTOGRAM_ISTILGANGSKONTROLL_PERSONER: Timer = Timer.builder(ISTILGANGSKONTROLL_HISTOGRAM_PERSONER)
+    .description("Measure the current time it takes to get a response from istilgangskontroll - personer")
     .register(METRICS_REGISTRY)
 
 val HISTOGRAM_ISTILGANGSKONTROLL_ENHET: Timer = Timer.builder(ISTILGANGSKONTROLL_HISTOGRAM_ENHET)

--- a/src/test/kotlin/no/nav/syfo/cronjob/preloadcache/PreloadCacheCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/preloadcache/PreloadCacheCronjobSpek.kt
@@ -29,7 +29,6 @@ object PreloadCacheCronjobSpek : Spek({
             database = database,
             tilgangskontrollClient = VeilederTilgangskontrollClient(
                 azureAdClient = azureAdClient,
-                syfotilgangskontrollEnv = externalMockEnvironment.environment.clients.syfotilgangskontroll,
                 istilgangskontrollEnv = externalMockEnvironment.environment.clients.istilgangskontroll,
             ),
             arenaCutoff = externalMockEnvironment.environment.arenaCutoff,

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -27,7 +27,6 @@ class ExternalMockEnvironment private constructor() {
         eregUrl = eregMock.url,
         pdlUrl = pdlMock.url,
         syfobehandlendeenhetUrl = syfobehandlendeenhetMock.url,
-        syfotilgangskontrollUrl = tilgangskontrollMock.url,
         istilgangskontrollUrl = tilgangskontrollMock.url,
         kafkaBootstrapServers = embeddedEnvironment.brokersURL
     )

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.testutil
 
-import io.ktor.http.*
-import no.nav.syfo.application.*
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
 import no.nav.syfo.application.cache.RedisEnvironment
 import no.nav.syfo.application.database.DatabaseEnvironment
 import no.nav.syfo.application.kafka.KafkaEnvironment
@@ -18,7 +18,6 @@ fun testEnvironment(
     eregUrl: String = "ereg",
     pdlUrl: String,
     syfobehandlendeenhetUrl: String = "syfobehandlendeenhet",
-    syfotilgangskontrollUrl: String = "syfotilgangskontroll",
     istilgangskontrollUrl: String = "istilgangskontroll",
 ) = Environment(
     applicationName = "syfooversiktsrv",
@@ -59,10 +58,6 @@ fun testEnvironment(
         syfobehandlendeenhet = ClientEnvironment(
             baseUrl = syfobehandlendeenhetUrl,
             clientId = "dev-gcp.teamsykefravr.syfobehandlendeenhet",
-        ),
-        syfotilgangskontroll = ClientEnvironment(
-            baseUrl = syfotilgangskontrollUrl,
-            clientId = "dev-gcp.teamsykefravr.syfotilgangskontroll",
         ),
         istilgangskontroll = ClientEnvironment(
             baseUrl = istilgangskontrollUrl,

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/VeilederTilgangskontrollMock.kt
@@ -33,10 +33,10 @@ class VeilederTilgangskontrollMock {
             get("/api/tilgang/navident/enhet/${UserConstants.NAV_ENHET}") {
                 call.respond(responseAccessEnhet)
             }
-            post("/syfo-tilgangskontroll/api/tilgang/navident/brukere") {
+            post("/api/tilgang/navident/brukere") {
                 call.respond(responseAccessPersons)
             }
-            post("/syfo-tilgangskontroll/api/tilgang/system/preloadbrukere") {
+            post("/api/tilgang/system/preloadbrukere") {
                 val identer = call.receive<List<String>>()
                 call.respond(
                     if (identer.contains(UserConstants.ARBEIDSTAKER_4_FNR_WITH_ERROR)) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Use new API for preloading cache and filtering list of people. We need to do both at the same time, because the filtering relies on stuff being cached in the same tilgangskontroll app. Remove syfo-tilgangskontroll which is no longer in use.
