### PR TITLE
IS-1894: Consume antallSykedager from oppfolgingstilfelle and calculate varighetUker in DTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -19,13 +19,26 @@ data class Oppfolgingstilfelle(
     val oppfolgingstilfelleBitReferanseInntruffet: OffsetDateTime,
     val oppfolgingstilfelleBitReferanseUuid: UUID,
     val virksomhetList: List<PersonOppfolgingstilfelleVirksomhet>,
-)
+) {
+    fun varighetUker(): Int {
+        val currentVarighetDaysBrutto = ChronoUnit.DAYS.between(oppfolgingstilfelleStart, minOf(LocalDate.now(), oppfolgingstilfelleEnd)) + 1
+        val currentVarighetDays = if (antallSykedager == null) {
+            currentVarighetDaysBrutto
+        } else {
+            val totalVarighetDays = ChronoUnit.DAYS.between(oppfolgingstilfelleStart, oppfolgingstilfelleEnd) + 1
+            val ikkeSykedager = totalVarighetDays - antallSykedager
+            currentVarighetDaysBrutto - ikkeSykedager
+        }
+        return currentVarighetDays.toInt() / DAYS_IN_WEEK
+    }
+}
 
 fun Oppfolgingstilfelle.toPersonOppfolgingstilfelleDTO() =
     PersonOppfolgingstilfelleDTO(
         oppfolgingstilfelleStart = this.oppfolgingstilfelleStart,
         oppfolgingstilfelleEnd = this.oppfolgingstilfelleEnd,
         virksomhetList = this.virksomhetList.toPersonOppfolgingstilfelleVirksomhetDTO(),
+        varighetUker = this.varighetUker(),
     )
 
 data class PersonOppfolgingstilfelleVirksomhet(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.oppfolgingstilfelle.domain
+
+import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.personstatus.api.v2.PersonOppfolgingstilfelleDTO
+import no.nav.syfo.personstatus.api.v2.PersonOppfolgingstilfelleVirksomhetDTO
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+private const val DAYS_IN_WEEK = 7
+
+data class Oppfolgingstilfelle(
+    val updatedAt: OffsetDateTime,
+    val generatedAt: OffsetDateTime,
+    val oppfolgingstilfelleStart: LocalDate,
+    val oppfolgingstilfelleEnd: LocalDate,
+    val antallSykedager: Int?,
+    val oppfolgingstilfelleBitReferanseInntruffet: OffsetDateTime,
+    val oppfolgingstilfelleBitReferanseUuid: UUID,
+    val virksomhetList: List<PersonOppfolgingstilfelleVirksomhet>,
+)
+
+fun Oppfolgingstilfelle.toPersonOppfolgingstilfelleDTO() =
+    PersonOppfolgingstilfelleDTO(
+        oppfolgingstilfelleStart = this.oppfolgingstilfelleStart,
+        oppfolgingstilfelleEnd = this.oppfolgingstilfelleEnd,
+        virksomhetList = this.virksomhetList.toPersonOppfolgingstilfelleVirksomhetDTO(),
+    )
+
+data class PersonOppfolgingstilfelleVirksomhet(
+    val uuid: UUID,
+    val createdAt: OffsetDateTime,
+    val virksomhetsnummer: Virksomhetsnummer,
+    val virksomhetsnavn: String?,
+)
+
+fun List<PersonOppfolgingstilfelleVirksomhet>.toPersonOppfolgingstilfelleVirksomhetDTO() =
+    this.map { virksomhet ->
+        PersonOppfolgingstilfelleVirksomhetDTO(
+            virksomhetsnummer = virksomhet.virksomhetsnummer.value,
+            virksomhetsnavn = virksomhet.virksomhetsnavn,
+        )
+    }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -27,7 +27,7 @@ data class Oppfolgingstilfelle(
         } else {
             val totalVarighetDays = ChronoUnit.DAYS.between(oppfolgingstilfelleStart, oppfolgingstilfelleEnd) + 1
             val ikkeSykedager = totalVarighetDays - antallSykedager
-            currentVarighetDaysBrutto - ikkeSykedager
+            maxOf(currentVarighetDaysBrutto - ikkeSykedager, 0)
         }
         return currentVarighetDays.toInt() / DAYS_IN_WEEK
     }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -3,12 +3,14 @@ package no.nav.syfo.oppfolgingstilfelle.domain
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.personstatus.api.v2.PersonOppfolgingstilfelleDTO
 import no.nav.syfo.personstatus.api.v2.PersonOppfolgingstilfelleVirksomhetDTO
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*
 
 private const val DAYS_IN_WEEK = 7
+private val log = LoggerFactory.getLogger(Oppfolgingstilfelle::class.java)
 
 data class Oppfolgingstilfelle(
     val updatedAt: OffsetDateTime,
@@ -27,6 +29,9 @@ data class Oppfolgingstilfelle(
         } else {
             val totalVarighetDays = ChronoUnit.DAYS.between(oppfolgingstilfelleStart, oppfolgingstilfelleEnd) + 1
             val ikkeSykedager = totalVarighetDays - antallSykedager
+            if (currentVarighetDaysBrutto - ikkeSykedager < 0) {
+                log.error("Calculation of varighetUker is a negative value for tilfellebitReferanseUuid=$oppfolgingstilfelleBitReferanseUuid")
+            }
             maxOf(currentVarighetDaysBrutto - ikkeSykedager, 0)
         }
         return currentVarighetDays.toInt() / DAYS_IN_WEEK

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePerson.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.oppfolgingstilfelle.kafka
 
 import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
+import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personstatus.domain.*
 import no.nav.syfo.util.nowUTC
 import java.time.LocalDate
@@ -20,6 +22,7 @@ data class KafkaOppfolgingstilfelle(
     val arbeidstakerAtTilfelleEnd: Boolean,
     val start: LocalDate,
     val end: LocalDate,
+    val antallSykedager: Int?,
     val virksomhetsnummerList: List<String>,
 )
 
@@ -68,4 +71,5 @@ fun KafkaOppfolgingstilfellePerson.toPersonOppfolgingstilfelle(
             virksomhetsnavn = null,
         )
     },
+    antallSykedager = latestKafkaOppfolgingstilfelle.antallSykedager,
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -2,10 +2,14 @@ package no.nav.syfo.oppfolgingstilfelle.kafka
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.kafka.KafkaConsumerService
-import no.nav.syfo.personstatus.db.*
+import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
+import no.nav.syfo.personstatus.db.createPersonOversiktStatus
+import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
+import no.nav.syfo.personstatus.db.updatePersonOversiktStatusOppfolgingstilfelle
 import no.nav.syfo.personstatus.domain.PPersonOversiktStatus
-import no.nav.syfo.personstatus.domain.Oppfolgingstilfelle
-import org.apache.kafka.clients.consumer.*
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.LoggerFactory
 import java.sql.Connection
 import java.sql.SQLException

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.personstatus
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personoppgavehendelse.kafka.*
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.personstatus.domain.*

--- a/src/main/kotlin/no/nav/syfo/personstatus/api/v2/PersonOversiktStatusDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/api/v2/PersonOversiktStatusDTO.kt
@@ -29,6 +29,7 @@ data class PersonOversiktStatusDTO(
 data class PersonOppfolgingstilfelleDTO(
     val oppfolgingstilfelleStart: LocalDate,
     val oppfolgingstilfelleEnd: LocalDate,
+    val varighetUker: Int,
     val virksomhetList: List<PersonOppfolgingstilfelleVirksomhetDTO>,
 )
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/PersonOppfolgingstilfelleVirksomhetQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/PersonOppfolgingstilfelleVirksomhetQuery.kt
@@ -1,9 +1,9 @@
-package no.nav.syfo.personstatus
+package no.nav.syfo.personstatus.db
 
 import no.nav.syfo.application.database.toList
 import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personstatus.domain.PPersonOppfolgingstilfelleVirksomhet
-import no.nav.syfo.personstatus.domain.PersonOppfolgingstilfelleVirksomhet
 import java.sql.Connection
 import java.sql.ResultSet
 import java.time.OffsetDateTime

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/createOrUpdatePersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/createOrUpdatePersonOversiktStatus.kt
@@ -113,7 +113,9 @@ fun Connection.createPersonOversiktStatus(
         it.setBoolean(31, personOversiktStatus.trengerOppfolging)
         it.setObject(32, personOversiktStatus.trengerOppfolgingFrist)
         it.setBoolean(33, personOversiktStatus.behandlerBerOmBistandUbehandlet)
-        it.setObject(34, personOversiktStatus.latestOppfolgingstilfelle?.antallSykedager)
+        if (personOversiktStatus.latestOppfolgingstilfelle?.antallSykedager != null) {
+            it.setInt(34, personOversiktStatus.latestOppfolgingstilfelle.antallSykedager)
+        } else it.setNull(34, Types.INTEGER)
         it.executeQuery().toList { getInt("id") }.firstOrNull()
     } ?: throw SQLException("Creating PersonOversikStatus failed, no rows affected.")
 
@@ -155,7 +157,9 @@ fun Connection.updatePersonOversiktStatusOppfolgingstilfelle(
         it.setString(5, oppfolgingstilfelle.oppfolgingstilfelleBitReferanseUuid.toString())
         it.setObject(6, oppfolgingstilfelle.oppfolgingstilfelleBitReferanseInntruffet)
         it.setObject(7, Timestamp.from(Instant.now()))
-        it.setObject(8, oppfolgingstilfelle.antallSykedager)
+        if (oppfolgingstilfelle.antallSykedager != null) {
+            it.setInt(8, oppfolgingstilfelle.antallSykedager)
+        } else it.setNull(8, Types.INTEGER)
         it.setString(9, pPersonOversiktStatus.fnr)
         it.execute()
     }

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/createOrUpdatePersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/createOrUpdatePersonOversiktStatus.kt
@@ -2,9 +2,8 @@ package no.nav.syfo.personstatus.db
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.database.toList
-import no.nav.syfo.personstatus.createPersonOppfolgingstilfelleVirksomhetList
+import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
 import no.nav.syfo.personstatus.domain.*
-import no.nav.syfo.personstatus.updatePersonOppfolgingstilfelleVirksomhetList
 import no.nav.syfo.util.nowUTC
 import java.sql.*
 import java.sql.Types.NULL
@@ -47,8 +46,9 @@ const val queryCreatePersonOversiktStatus =
         aktivitetskrav_vurder_stans_ubehandlet,
         trenger_oppfolging,
         trenger_oppfolging_frist,
-        behandler_bistand_ubehandlet
-    ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        behandler_bistand_ubehandlet,
+        antall_sykedager
+    ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     RETURNING id
     """
 
@@ -113,6 +113,7 @@ fun Connection.createPersonOversiktStatus(
         it.setBoolean(31, personOversiktStatus.trengerOppfolging)
         it.setObject(32, personOversiktStatus.trengerOppfolgingFrist)
         it.setBoolean(33, personOversiktStatus.behandlerBerOmBistandUbehandlet)
+        it.setObject(34, personOversiktStatus.latestOppfolgingstilfelle?.antallSykedager)
         it.executeQuery().toList { getInt("id") }.firstOrNull()
     } ?: throw SQLException("Creating PersonOversikStatus failed, no rows affected.")
 
@@ -137,7 +138,8 @@ const val queryUpdatePersonOversiktStatusOppfolgingstilfelle =
     oppfolgingstilfelle_end = ?,
     oppfolgingstilfelle_bit_referanse_uuid = ?,
     oppfolgingstilfelle_bit_referanse_inntruffet = ?,
-    sist_endret = ?
+    sist_endret = ?,
+    antall_sykedager = ?
     WHERE fnr = ?
     """
 
@@ -153,7 +155,8 @@ fun Connection.updatePersonOversiktStatusOppfolgingstilfelle(
         it.setString(5, oppfolgingstilfelle.oppfolgingstilfelleBitReferanseUuid.toString())
         it.setObject(6, oppfolgingstilfelle.oppfolgingstilfelleBitReferanseInntruffet)
         it.setObject(7, Timestamp.from(Instant.now()))
-        it.setString(8, pPersonOversiktStatus.fnr)
+        it.setObject(8, oppfolgingstilfelle.antallSykedager)
+        it.setString(9, pPersonOversiktStatus.fnr)
         it.execute()
     }
     updatePersonOppfolgingstilfelleVirksomhetList(

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
@@ -120,6 +120,7 @@ fun ResultSet.toPPersonOversiktStatus(): PPersonOversiktStatus =
         trengerOppfolging = getObject("trenger_oppfolging") as Boolean,
         trengerOppfolgingFrist = getObject("trenger_oppfolging_frist", LocalDate::class.java),
         behandlerBerOmBistandUbehandlet = getObject("behandler_bistand_ubehandlet") as Boolean,
+        antallSykedager = getObject("antall_sykedager") as Int?,
     )
 
 fun ResultSet.toVeilederBrukerKnytning(): VeilederBrukerKnytning =

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PPersonOppfolgingstilfelleVirksomhet.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PPersonOppfolgingstilfelleVirksomhet.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.personstatus.domain
 
 import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import java.time.OffsetDateTime
 import java.util.*
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PPersonOversiktStatus.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.personstatus.domain
 
 import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
+import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
+import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -37,6 +39,7 @@ data class PPersonOversiktStatus(
     val trengerOppfolging: Boolean,
     val trengerOppfolgingFrist: LocalDate?,
     val behandlerBerOmBistandUbehandlet: Boolean,
+    val antallSykedager: Int?,
 )
 
 fun PPersonOversiktStatus.toPersonOversiktStatus(
@@ -88,6 +91,7 @@ fun PPersonOversiktStatus.toPersonOppfolgingstilfelle(
             oppfolgingstilfelleBitReferanseInntruffet = this.oppfolgingstilfelleBitReferanseInntruffet,
             oppfolgingstilfelleBitReferanseUuid = this.oppfolgingstilfelleBitReferanseUuid,
             virksomhetList = personOppfolgingstilfelleVirksomhetList,
+            antallSykedager = this.antallSykedager,
         )
     } else {
         null

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -2,12 +2,14 @@ package no.nav.syfo.personstatus.domain
 
 import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
 import no.nav.syfo.dialogmotestatusendring.domain.DialogmoteStatusendringType
-import no.nav.syfo.domain.Virksomhetsnummer
-import no.nav.syfo.personstatus.api.v2.*
-import no.nav.syfo.util.*
+import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
+import no.nav.syfo.oppfolgingstilfelle.domain.toPersonOppfolgingstilfelleDTO
+import no.nav.syfo.personstatus.api.v2.PersonOversiktStatusDTO
+import no.nav.syfo.util.isBeforeOrEqual
+import no.nav.syfo.util.toLocalDateOslo
+import no.nav.syfo.util.toLocalDateTimeOslo
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.*
 
 data class PersonOversiktStatus(
     val veilederIdent: String?,
@@ -72,38 +74,6 @@ fun PersonOversiktStatus.hasActiveOppgave(arenaCutoff: LocalDate): Boolean {
         this.aktivitetskravVurderStansUbehandlet ||
         this.trengerOppfolging || this.behandlerBerOmBistandUbehandlet
 }
-
-data class Oppfolgingstilfelle(
-    val updatedAt: OffsetDateTime,
-    val generatedAt: OffsetDateTime,
-    val oppfolgingstilfelleStart: LocalDate,
-    val oppfolgingstilfelleEnd: LocalDate,
-    val oppfolgingstilfelleBitReferanseInntruffet: OffsetDateTime,
-    val oppfolgingstilfelleBitReferanseUuid: UUID,
-    val virksomhetList: List<PersonOppfolgingstilfelleVirksomhet>,
-)
-
-fun Oppfolgingstilfelle.toPersonOppfolgingstilfelleDTO() =
-    PersonOppfolgingstilfelleDTO(
-        oppfolgingstilfelleStart = this.oppfolgingstilfelleStart,
-        oppfolgingstilfelleEnd = this.oppfolgingstilfelleEnd,
-        virksomhetList = this.virksomhetList.toPersonOppfolgingstilfelleVirksomhetDTO()
-    )
-
-data class PersonOppfolgingstilfelleVirksomhet(
-    val uuid: UUID,
-    val createdAt: OffsetDateTime,
-    val virksomhetsnummer: Virksomhetsnummer,
-    val virksomhetsnavn: String?,
-)
-
-fun List<PersonOppfolgingstilfelleVirksomhet>.toPersonOppfolgingstilfelleVirksomhetDTO() =
-    this.map { virksomhet ->
-        PersonOppfolgingstilfelleVirksomhetDTO(
-            virksomhetsnummer = virksomhet.virksomhetsnummer.value,
-            virksomhetsnavn = virksomhet.virksomhetsnavn,
-        )
-    }
 
 fun List<PersonOversiktStatus>.addPersonName(
     personIdentNameMap: Map<String, String>,

--- a/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
@@ -9,7 +9,6 @@ import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskravvurdering.persistAktivitetskrav
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.personoppgavehendelse.kafka.KPersonoppgavehendelse
-import no.nav.syfo.personstatus.*
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.personstatus.domain.OversikthendelseType
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus

--- a/src/test/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek.kt
@@ -11,7 +11,7 @@ import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.personoppgavehendelse.kafka.KPersonoppgavehendelse
 import no.nav.syfo.personstatus.domain.OversikthendelseType
-import no.nav.syfo.personstatus.getPersonOppfolgingstilfelleVirksomhetList
+import no.nav.syfo.personstatus.db.getPersonOppfolgingstilfelleVirksomhetList
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import no.nav.syfo.personstatus.domain.applyHendelse

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
@@ -19,7 +19,7 @@ class OppfolgingstilfelleSpek : Spek({
             oppfolgingstilfelle.varighetUker() shouldBeEqualTo 2
         }
 
-        it("Calculates varighet based on start and end when end is in the future") {
+        it("Calculates varighet based on start and now when end is in the future") {
             val oppfolgingstilfelle = generateOppfolgingstilfelle(
                 start = LocalDate.now().minusDays(19),
                 end = LocalDate.now().plusDays(1),
@@ -37,6 +37,26 @@ class OppfolgingstilfelleSpek : Spek({
             )
 
             oppfolgingstilfelle.varighetUker() shouldBeEqualTo 1
+        }
+        
+        it("Calculates varighet based on start and antallSykedager when end is in the future") {
+            val oppfolgingstilfelle = generateOppfolgingstilfelle(
+                start = LocalDate.now().minusDays(19),
+                end = LocalDate.now().plusDays(100),
+                antallSykedager = 110,
+            )
+            
+            oppfolgingstilfelle.varighetUker() shouldBeEqualTo 1
+        }
+        
+        it("Sets varighet to 0 when missing sykedager in the future") {
+            val oppfolgingstilfelle = generateOppfolgingstilfelle(
+                start = LocalDate.now().minusDays(19),
+                end = LocalDate.now().plusDays(100),
+                antallSykedager = 10,
+            )
+            
+            oppfolgingstilfelle.varighetUker() shouldBeEqualTo 0
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
@@ -1,0 +1,42 @@
+package no.nav.syfo.oppfolgingstilfelle.domain
+
+import no.nav.syfo.testutil.generator.generateOppfolgingstilfelle
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+
+class OppfolgingstilfelleSpek : Spek({
+
+    describe("Varighet uker") {
+        it("Calculates varighet based on start and end") {
+            val oppfolgingstilfelle = generateOppfolgingstilfelle(
+                start = LocalDate.now().minusDays(19),
+                end = LocalDate.now(),
+                antallSykedager = null,
+            )
+
+            oppfolgingstilfelle.varighetUker() shouldBeEqualTo 2
+        }
+
+        it("Calculates varighet based on start and end when end is in the future") {
+            val oppfolgingstilfelle = generateOppfolgingstilfelle(
+                start = LocalDate.now().minusDays(19),
+                end = LocalDate.now().plusDays(1),
+                antallSykedager = null,
+            )
+
+            oppfolgingstilfelle.varighetUker() shouldBeEqualTo 2
+        }
+
+        it("Calculates varighet based on start and antallSykedager") {
+            val oppfolgingstilfelle = generateOppfolgingstilfelle(
+                start = LocalDate.now().minusDays(19),
+                end = LocalDate.now(),
+                antallSykedager = 10,
+            )
+
+            oppfolgingstilfelle.varighetUker() shouldBeEqualTo 1
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
@@ -38,24 +38,24 @@ class OppfolgingstilfelleSpek : Spek({
 
             oppfolgingstilfelle.varighetUker() shouldBeEqualTo 1
         }
-        
+
         it("Calculates varighet based on start and antallSykedager when end is in the future") {
             val oppfolgingstilfelle = generateOppfolgingstilfelle(
                 start = LocalDate.now().minusDays(19),
                 end = LocalDate.now().plusDays(100),
                 antallSykedager = 110,
             )
-            
+
             oppfolgingstilfelle.varighetUker() shouldBeEqualTo 1
         }
-        
+
         it("Sets varighet to 0 when missing sykedager in the future") {
             val oppfolgingstilfelle = generateOppfolgingstilfelle(
                 start = LocalDate.now().minusDays(19),
                 end = LocalDate.now().plusDays(100),
                 antallSykedager = 10,
             )
-            
+
             oppfolgingstilfelle.varighetUker() shouldBeEqualTo 0
         }
     }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus
+package no.nav.syfo.oppfolgingstilfelle.kafka
 
 import io.ktor.server.testing.*
 import io.ktor.util.*
@@ -6,7 +6,6 @@ import io.mockk.clearMocks
 import io.mockk.every
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
-import no.nav.syfo.oppfolgingstilfelle.kafka.KafkaOppfolgingstilfelle
 import no.nav.syfo.personoppgavehendelse.kafka.KPersonoppgavehendelse
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.personstatus.domain.OversikthendelseType

--- a/src/test/kotlin/no/nav/syfo/personstatus/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -484,6 +484,7 @@ object KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                             start = oppfolgingstilfelle.start.minusDays(7),
                             end = oppfolgingstilfelle.end,
                             virksomhetsnummerList = oppfolgingstilfelle.virksomhetsnummerList,
+                            antallSykedager = oppfolgingstilfelle.antallSykedager,
                         ),
                     )
                 )

--- a/src/test/kotlin/no/nav/syfo/testutil/assertion/PPersonOversiktStatusAssertion.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/assertion/PPersonOversiktStatusAssertion.kt
@@ -24,4 +24,5 @@ fun checkPPersonOversiktStatusOppfolgingstilfelle(
         .toEpochMilli()
     pPersonOversiktStatus.oppfolgingstilfelleBitReferanseInntruffet?.offset shouldBeEqualTo kafkaOppfolgingstilfellePerson.referanseTilfelleBitInntruffet.offset
     pPersonOversiktStatus.oppfolgingstilfelleBitReferanseUuid.toString() shouldBeEqualTo kafkaOppfolgingstilfellePerson.referanseTilfelleBitUuid
+    pPersonOversiktStatus.antallSykedager shouldBeEqualTo latestOppfolgingstilfelle.antallSykedager
 }

--- a/src/test/kotlin/no/nav/syfo/testutil/assertion/PersonOversiktStatusDTOAssertion.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/assertion/PersonOversiktStatusDTOAssertion.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.testutil.assertion
 
 import no.nav.syfo.oppfolgingstilfelle.kafka.KafkaOppfolgingstilfellePerson
+import no.nav.syfo.oppfolgingstilfelle.kafka.toPersonOppfolgingstilfelle
 import no.nav.syfo.personstatus.api.v2.PersonOppfolgingstilfelleDTO
 import no.nav.syfo.personstatus.api.v2.PersonOppfolgingstilfelleVirksomhetDTO
 import no.nav.syfo.testutil.mock.eregOrganisasjonResponse
@@ -19,6 +20,7 @@ fun checkPersonOppfolgingstilfelleDTO(
 
     personOppfolgingstilfelleDTO.oppfolgingstilfelleStart shouldBeEqualTo latestOppfolgingstilfelle.start
     personOppfolgingstilfelleDTO.oppfolgingstilfelleEnd shouldBeEqualTo latestOppfolgingstilfelle.end
+    personOppfolgingstilfelleDTO.varighetUker shouldBeEqualTo kafkaOppfolgingstilfellePerson.toPersonOppfolgingstilfelle(latestOppfolgingstilfelle).varighetUker()
 
     checkPersonOppfolgingstilfelleVirksomhetDTOList(
         personOppfolgingstilfelleVirksomhetDTOList = personOppfolgingstilfelleDTO.virksomhetList,

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/KafkaOppfolgingstilfellePersonGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/KafkaOppfolgingstilfellePersonGenerator.kt
@@ -34,6 +34,7 @@ fun generateKafkaOppfolgingstilfellePerson(
                 virksomhetsnummerList = virksomhetsnummerList.map { virksomhetsnummer ->
                     virksomhetsnummer.value
                 },
+                antallSykedager = oppfolgingstilfelleDurationInDays.toInt(),
             ),
         ),
         referanseTilfelleBitUuid = UUID.randomUUID().toString(),

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/KafkaOppfolgingstilfellePersonGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/KafkaOppfolgingstilfellePersonGenerator.kt
@@ -20,6 +20,7 @@ fun generateKafkaOppfolgingstilfellePerson(
     virksomhetsnummerList: List<Virksomhetsnummer> = listOf(
         Virksomhetsnummer(VIRKSOMHETSNUMMER)
     ),
+    antallSykedager: Int? = oppfolgingstilfelleDurationInDays.toInt()
 ): KafkaOppfolgingstilfellePerson {
     val start = end.minusDays(oppfolgingstilfelleDurationInDays)
     return KafkaOppfolgingstilfellePerson(
@@ -34,7 +35,7 @@ fun generateKafkaOppfolgingstilfellePerson(
                 virksomhetsnummerList = virksomhetsnummerList.map { virksomhetsnummer ->
                     virksomhetsnummer.value
                 },
-                antallSykedager = oppfolgingstilfelleDurationInDays.toInt(),
+                antallSykedager = antallSykedager,
             ),
         ),
         referanseTilfelleBitUuid = UUID.randomUUID().toString(),

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/OppfolgingstilfelleGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/OppfolgingstilfelleGenerator.kt
@@ -6,9 +6,9 @@ import java.time.OffsetDateTime
 import java.util.*
 
 fun generateOppfolgingstilfelle(
-    start: LocalDate = LocalDate.now().minusDays(1),
-    end: LocalDate = LocalDate.now(),
-    antallSykedager: Int? = null
+    start: LocalDate,
+    end: LocalDate,
+    antallSykedager: Int?,
 ) = Oppfolgingstilfelle(
     updatedAt = OffsetDateTime.now(),
     generatedAt = OffsetDateTime.now(),

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/OppfolgingstilfelleGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/OppfolgingstilfelleGenerator.kt
@@ -1,0 +1,21 @@
+package no.nav.syfo.testutil.generator
+
+import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+fun generateOppfolgingstilfelle(
+    start: LocalDate = LocalDate.now().minusDays(1),
+    end: LocalDate = LocalDate.now(),
+    antallSykedager: Int? = null
+) = Oppfolgingstilfelle(
+    updatedAt = OffsetDateTime.now(),
+    generatedAt = OffsetDateTime.now(),
+    oppfolgingstilfelleStart = start,
+    oppfolgingstilfelleEnd = end,
+    antallSykedager = antallSykedager,
+    oppfolgingstilfelleBitReferanseInntruffet = OffsetDateTime.now(),
+    oppfolgingstilfelleBitReferanseUuid = UUID.randomUUID(),
+    virksomhetList = emptyList(),
+)

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/PPersonOversiktStatusGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/PPersonOversiktStatusGenerator.kt
@@ -36,4 +36,5 @@ fun generatePPersonOversiktStatus(fnr: String = UserConstants.ARBEIDSTAKER_FNR) 
     trengerOppfolging = false,
     trengerOppfolgingFrist = null,
     behandlerBerOmBistandUbehandlet = false,
+    antallSykedager = null,
 )


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Etter siste endringer på oppfølgingstilfelle får man nå inn `antallSykedager` på kafka. Dette vil vi lagre i databasen, og bruke til å kalkulere varigheten på sykefraværet i uker. Bruker samme utregning for varighetUker som i [denne PRen](https://github.com/navikt/isoppfolgingstilfelle/pull/165/files#diff-6e96db1980cdcec11d3dfb14b5eec8de9e0dc39b48f139d465b4fd9cf702eb36).

Har også flyttet på `Oppfolgingstilfelle`-klassen, inn i sin egen mappe. Dette fører til litt diffs i imports. 
Denne er nok lettere å lese commit for commit sånn sett.

### Quizinfo
1894 er året Coca Cola selges for første gang på flasker, og Nikita Khrusjtsjov ble født.