### PR TITLE
IS-1894: Only log when varighet is negative and oppfolgingstilfelleStart is in the past

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -29,12 +29,12 @@ data class Oppfolgingstilfelle(
         } else {
             val totalVarighetDays = ChronoUnit.DAYS.between(oppfolgingstilfelleStart, oppfolgingstilfelleEnd) + 1
             val ikkeSykedager = totalVarighetDays - antallSykedager
-            if (currentVarighetDaysBrutto - ikkeSykedager < 0) {
+            if (currentVarighetDaysBrutto - ikkeSykedager < 0 && oppfolgingstilfelleStart < LocalDate.now()) {
                 log.error("Calculation of varighetUker is a negative value for tilfellebitReferanseUuid=$oppfolgingstilfelleBitReferanseUuid")
             }
-            maxOf(currentVarighetDaysBrutto - ikkeSykedager, 0)
+            currentVarighetDaysBrutto - ikkeSykedager
         }
-        return currentVarighetDays.toInt() / DAYS_IN_WEEK
+        return maxOf(currentVarighetDays.toInt() / DAYS_IN_WEEK, 0)
     }
 }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleSpek.kt
@@ -58,5 +58,15 @@ class OppfolgingstilfelleSpek : Spek({
 
             oppfolgingstilfelle.varighetUker() shouldBeEqualTo 0
         }
+
+        it("Sets varighet to 0 when start is in the future") {
+            val oppfolgingstilfelle = generateOppfolgingstilfelle(
+                start = LocalDate.now().plusDays(9),
+                end = LocalDate.now().plusDays(20),
+                antallSykedager = null,
+            )
+
+            oppfolgingstilfelle.varighetUker() shouldBeEqualTo 0
+        }
     }
 })


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi ser at noen oppfølgingstilfeller har negativ varighet fordi det begynner i fremtiden. Akkurat disse casene er sånn sett greie at får varighet 0, og er ikke noe som trenger å logges/undersøkes nærmere.
