### PR TITLE
Update behandlende enhet on received active oppfolgingsoppgave

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -13,7 +13,9 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.database.database
 import no.nav.syfo.application.database.databaseModule
 import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 import no.nav.syfo.cronjob.launchCronjobModule
 import no.nav.syfo.kafka.launchKafkaModule
 import no.nav.syfo.personstatus.PersonoversiktStatusService
@@ -45,7 +47,12 @@ fun main() {
         azureAdClient = azureAdClient,
         clientEnvironment = environment.clients.pdl,
     )
+    val behandlendeEnhetClient = BehandlendeEnhetClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = environment.clients.syfobehandlendeenhet,
+    )
 
+    lateinit var personBehandlendeEnhetService: PersonBehandlendeEnhetService
     lateinit var personoversiktStatusService: PersonoversiktStatusService
 
     val applicationEngineEnvironment = applicationEngineEnvironment {
@@ -63,6 +70,10 @@ fun main() {
             personoversiktStatusService = PersonoversiktStatusService(
                 database = database,
                 pdlClient = pdlClient,
+            )
+            personBehandlendeEnhetService = PersonBehandlendeEnhetService(
+                database = database,
+                behandlendeEnhetClient = behandlendeEnhetClient,
             )
             apiModule(
                 applicationState = applicationState,
@@ -92,6 +103,7 @@ fun main() {
             environment = environment,
             azureAdClient = azureAdClient,
             personoversiktStatusService = personoversiktStatusService,
+            personBehandlendeEnhetService = personBehandlendeEnhetService,
         )
         launchCronjobModule(
             applicationState = applicationState,
@@ -99,6 +111,7 @@ fun main() {
             environment = environment,
             redisStore = redisStore,
             azureAdClient = azureAdClient,
+            personBehandlendeEnhetService = personBehandlendeEnhetService,
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.application.backgroundtask.launchBackgroundTask
 import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.client.azuread.AzureAdClient
-import no.nav.syfo.client.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.client.ereg.EregClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetCronjob
@@ -24,6 +23,7 @@ fun launchCronjobModule(
     environment: Environment,
     redisStore: RedisStore,
     azureAdClient: AzureAdClient,
+    personBehandlendeEnhetService: PersonBehandlendeEnhetService,
 ) {
     val eregClient = EregClient(
         clientEnvironment = environment.clients.ereg,
@@ -37,14 +37,6 @@ fun launchCronjobModule(
         personOppfolgingstilfelleVirksomhetsnavnService = personOppfolgingstilfelleVirksomhetsnavnService,
     )
 
-    val behandlendeEnhetClient = BehandlendeEnhetClient(
-        azureAdClient = azureAdClient,
-        clientEnvironment = environment.clients.syfobehandlendeenhet,
-    )
-    val personBehandlendeEnhetService = PersonBehandlendeEnhetService(
-        database = database,
-        behandlendeEnhetClient = behandlendeEnhetClient,
-    )
     val personBehandlendeEnhetCronjob = PersonBehandlendeEnhetCronjob(
         personBehandlendeEnhetService = personBehandlendeEnhetService,
         intervalDelayMinutes = environment.cronjobBehandlendeEnhetIntervalDelayMinutes,

--- a/src/main/kotlin/no/nav/syfo/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/KafkaModule.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.aktivitetskravvurdering.kafka.launchKafkaTaskAktivitetskravVu
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 import no.nav.syfo.dialogmotekandidat.kafka.launchKafkaTaskDialogmotekandidatEndring
 import no.nav.syfo.dialogmotestatusendring.kafka.launchKafkaTaskDialogmoteStatusendring
 import no.nav.syfo.trengeroppfolging.kafka.launchTrengerOppfolgingConsumer
@@ -18,6 +19,7 @@ fun launchKafkaModule(
     environment: Environment,
     azureAdClient: AzureAdClient,
     personoversiktStatusService: PersonoversiktStatusService,
+    personBehandlendeEnhetService: PersonBehandlendeEnhetService,
 ) {
     launchKafkaTaskPersonoppgavehendelse(
         applicationState = applicationState,
@@ -56,5 +58,6 @@ fun launchKafkaModule(
     launchTrengerOppfolgingConsumer(
         applicationState = applicationState,
         kafkaEnvironment = environment.kafka,
+        personBehandlendeEnhetService = personBehandlendeEnhetService,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/trengeroppfolging/TrengerOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/trengeroppfolging/TrengerOppfolgingService.kt
@@ -1,6 +1,11 @@
 package no.nav.syfo.trengeroppfolging
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
+import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.trengeroppfolging.domain.TrengerOppfolging
 import no.nav.syfo.trengeroppfolging.kafka.COUNT_KAFKA_CONSUMER_TRENGER_OPPFOLGING_READ
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
@@ -11,8 +16,19 @@ import org.slf4j.LoggerFactory
 
 class TrengerOppfolgingService(
     private val database: DatabaseInterface,
+    private val personBehandlendeEnhetService: PersonBehandlendeEnhetService,
 ) {
     fun processTrengerOppfolging(records: List<TrengerOppfolging>) {
+        createOrUpdatePersonOversiktStatus(records)
+        records.filter { it.isActive }.forEach {
+            val personOversiktStatus = database.getPersonOversiktStatusList(
+                fnr = it.personIdent.value,
+            ).first()
+            updateBehandlendeEnhet(it.personIdent, personOversiktStatus.enhet)
+        }
+    }
+
+    private fun createOrUpdatePersonOversiktStatus(records: List<TrengerOppfolging>) {
         database.connection.use { connection ->
             records.forEach { trengerOppfolging ->
                 val existingPersonOversiktStatus = connection.getPersonOversiktStatusList(
@@ -33,6 +49,25 @@ class TrengerOppfolgingService(
                 COUNT_KAFKA_CONSUMER_TRENGER_OPPFOLGING_READ.increment()
             }
             connection.commit()
+        }
+    }
+
+    private fun updateBehandlendeEnhet(
+        personIdent: PersonIdent,
+        existingEnhet: String?
+    ) {
+        try {
+            runBlocking {
+                launch(Dispatchers.IO) {
+                    personBehandlendeEnhetService.updateBehandlendeEnhet(
+                        personIdent = personIdent,
+                        tildeltEnhet = existingEnhet
+                    )
+                    log.info("Updated Behandlende Enhet of person after received active oppfolgingsoppgave")
+                }
+            }
+        } catch (ex: Exception) {
+            log.error("Exception caught while attempting to update Behandlende Enhet of person after received active oppfolgingsoppgave", ex)
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/trengeroppfolging/kafka/TrengerOppfolgingTask.kt
+++ b/src/main/kotlin/no/nav/syfo/trengeroppfolging/kafka/TrengerOppfolgingTask.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.database.database
 import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.application.kafka.kafkaAivenConsumerConfig
+import no.nav.syfo.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 import no.nav.syfo.trengeroppfolging.TrengerOppfolgingService
 import no.nav.syfo.kafka.launchKafkaTask
 import no.nav.syfo.util.configuredJacksonMapper
@@ -17,9 +18,11 @@ const val HUSKELAPP_TOPIC =
 fun launchTrengerOppfolgingConsumer(
     applicationState: ApplicationState,
     kafkaEnvironment: KafkaEnvironment,
+    personBehandlendeEnhetService: PersonBehandlendeEnhetService,
 ) {
     val trengerOppfolgingService = TrengerOppfolgingService(
-        database = database
+        database = database,
+        personBehandlendeEnhetService = personBehandlendeEnhetService,
     )
     val trengerOppfolgingConsumer = TrengerOppfolgingConsumer(
         trengerOppfolgingService = trengerOppfolgingService,

--- a/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
@@ -36,7 +36,7 @@ class InternalMockEnvironment private constructor() {
         redisStore = redisStore,
     )
 
-    private val personBehandlendeEnhetService = PersonBehandlendeEnhetService(
+    internal val personBehandlendeEnhetService = PersonBehandlendeEnhetService(
         database = database,
         behandlendeEnhetClient = behandlendeEnhetClient,
     )


### PR DESCRIPTION
Mulig løsning på at personer ikke dukker raskt nok opp i oversikten når det lages oppfølgingsoppgave.

Når vi mottar records med oppfølgingsoppgave og har lagret/oppdatert personene i oversikten, går vi i tillegg gjennom records med aktiv oppfølgingsoppgave og gjør et forsøk på å oppdatere tildelt enhet for disse personene.
Dersom noe feiler logges dette (og personen vil bli plukket opp av den "vanlige" cronjobben som oppdatere tildelt enhet).

Tanker/innspill?