### PR TITLE
IS-2086: Add test for isDialogmotekandidat logic

### DIFF
--- a/src/test/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatusSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatusSpek.kt
@@ -2,23 +2,72 @@ package no.nav.syfo.personstatus.domain
 
 import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskravvurdering.domain.toPersonOversiktStatus
+import no.nav.syfo.dialogmotekandidat.kafka.toPersonOversiktStatus
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.testutil.UserConstants
 import no.nav.syfo.testutil.generator.AktivitetskravGenerator
+import no.nav.syfo.testutil.generator.generateKafkaDialogmotekandidatEndringStoppunkt
+import no.nav.syfo.testutil.generator.generateOppfolgingstilfelle
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 val arenaCutoff: LocalDate = LocalDate.now()
 
-class PersonOversikstStatusSpek : Spek({
-    val aktivitetskravGenerator = AktivitetskravGenerator(
-        arenaCutoff = arenaCutoff,
-    )
+class PersonOversiktStatusSpek : Spek({
     val defaultPersonident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR)
 
+    describe("isDialogmotekandidat") {
+        val activeOppfolgingstilfelle = generateOppfolgingstilfelle(
+            start = LocalDate.now().minusWeeks(2),
+            end = LocalDate.now().plusDays(5),
+            antallSykedager = 19
+        )
+
+        /*
+         * Vi lar det gå syv dager fra personen er generert som dialogmøtekandidat til de dukker opp i oversikten slik at partene rekker å svare på møtebehov.
+         */
+        it("returns true if dialogmotekandidat generated after start of latest oppfolgingstilfelle and more than seven days ago") {
+            val dialogmotekandidatEndring = generateKafkaDialogmotekandidatEndringStoppunkt(
+                personIdent = defaultPersonident.value,
+                createdAt = OffsetDateTime.now().minusDays(8),
+            )
+            val personOversiktStatus = dialogmotekandidatEndring.toPersonOversiktStatus()
+                .copy(
+                    latestOppfolgingstilfelle = activeOppfolgingstilfelle
+                )
+            personOversiktStatus.isDialogmotekandidat() shouldBeEqualTo true
+        }
+        it("returns true if dialogmotekandidat generated after start of latest oppfolgingstilfelle and seven days ago") {
+            val dialogmotekandidatEndring = generateKafkaDialogmotekandidatEndringStoppunkt(
+                personIdent = defaultPersonident.value,
+                createdAt = OffsetDateTime.now().minusDays(7),
+            )
+            val personOversiktStatus = dialogmotekandidatEndring.toPersonOversiktStatus()
+                .copy(
+                    latestOppfolgingstilfelle = activeOppfolgingstilfelle
+                )
+            personOversiktStatus.isDialogmotekandidat() shouldBeEqualTo true
+        }
+        it("returns false if dialogmotekandidat generated after start of latest oppfolgingstilfelle but less than seven days ago") {
+            val dialogmotekandidatEndring = generateKafkaDialogmotekandidatEndringStoppunkt(
+                personIdent = defaultPersonident.value,
+                createdAt = OffsetDateTime.now().minusDays(6),
+            )
+            val personOversiktStatus = dialogmotekandidatEndring.toPersonOversiktStatus()
+                .copy(
+                    latestOppfolgingstilfelle = activeOppfolgingstilfelle
+                )
+            personOversiktStatus.isDialogmotekandidat() shouldBeEqualTo false
+        }
+    }
+
     describe("isActiveAktivitetskrav") {
+        val aktivitetskravGenerator = AktivitetskravGenerator(
+            arenaCutoff = arenaCutoff,
+        )
         it("returns true if AktivitetskravStatus is NY and stoppunkt after arena cutoff") {
             val person = aktivitetskravGenerator.generateAktivitetskrav(
                 personIdent = defaultPersonident,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det kom inn en [Jira](https://jira.adeo.no/browse/FAGSYSTEM-318470)-sak hvor personen vises som dialogmøtekandidat i syfomodiaperson, men uten dialogmøtekandidat-hendelse i oversikten. Årsaken er at vi venter en uke med å vise personen som dialogmøtekandidat i oversikten for å gi partene mulighet til å besvare møtebehov først. La til en test for å dokumentere dette bedre.
Tenkte også å lage en PR på Api-et i isdialogmøtekandidat slik at personen ikke dukker opp for tidlig som kandidat i syfomodiaperson.
