### PR TITLE
IS-2372: Adjust friskmelding_til_arbeidsformidling_fom sql clause

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
@@ -70,7 +70,7 @@ const val queryGetPersonerWithOppgaveAndOldEnhet =
         OR trenger_oppfolging = 't'
         OR behandler_bistand_ubehandlet = 't'
         OR arbeidsuforhet_vurder_avslag_ubehandlet = 't'
-        OR (friskmelding_til_arbeidsformidling_fom IS NOT NULL AND friskmelding_til_arbeidsformidling_fom >= CURRENT_DATE) 
+        OR friskmelding_til_arbeidsformidling_fom IS NOT NULL 
         )
     AND (tildelt_enhet_updated_at IS NULL OR tildelt_enhet_updated_at <= NOW() - INTERVAL '24 HOURS')
     ORDER BY tildelt_enhet_updated_at ASC

--- a/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
@@ -43,7 +43,7 @@ const val queryPersonOppfolgingstilfelleVirksomhetNoVirksomhetsnavnList =
         OR trenger_oppfolging = 't'
         OR behandler_bistand_ubehandlet = 't'
         OR arbeidsuforhet_vurder_avslag_ubehandlet = 't'
-        OR (friskmelding_til_arbeidsformidling_fom IS NOT NULL AND friskmelding_til_arbeidsformidling_fom >= CURRENT_DATE)
+        OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
         )
     ORDER BY PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET.created_at ASC
     LIMIT 1000

--- a/src/main/kotlin/no/nav/syfo/frisktilarbeid/kafka/KafkaFriskTilArbeidMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/frisktilarbeid/kafka/KafkaFriskTilArbeidMetric.kt
@@ -12,17 +12,17 @@ const val KAFKA_CONSUMER_FRISKTILARBEID_UPDATE = "${KAFKA_CONSUMER_FRISKTILARBEI
 
 val COUNT_KAFKA_CONSUMER_FRISKTILARBEID_READ: Counter =
     Counter.builder(KAFKA_CONSUMER_FRISKTILARBEID_READ)
-        .description("Counts the number of reads from topic - isfrisktilarbeid-vedtak-fattet")
+        .description("Counts the number of reads from topic - isfrisktilarbeid-vedtak-status")
         .register(METRICS_REGISTRY)
 val COUNT_KAFKA_CONSUMER_FRISKTILARBEID_TOMBSTONE: Counter =
     Counter.builder(KAFKA_CONSUMER_FRISKTILARBEID_TOMBSTONE)
-        .description("Counts the number of tombstones received from topic - isfrisktilarbeid-vedtak-fattet")
+        .description("Counts the number of tombstones received from topic - isfrisktilarbeid-vedtak-status")
         .register(METRICS_REGISTRY)
 val COUNT_KAFKA_CONSUMER_FRISKTILARBEID_CREATED_PERSONOVERSIKT_STATUS: Counter =
     Counter.builder(KAFKA_CONSUMER_FRISKTILARBEID_CREATE)
-        .description("Counts the number of personoversikt-status created from reading topic - isfrisktilarbeid-vedtak-fattet")
+        .description("Counts the number of personoversikt-status created from reading topic - isfrisktilarbeid-vedtak-status")
         .register(METRICS_REGISTRY)
 val COUNT_KAFKA_CONSUMER_FRISKTILARBEID_UPDATED_PERSONOVERSIKT_STATUS: Counter =
     Counter.builder(KAFKA_CONSUMER_FRISKTILARBEID_UPDATE)
-        .description("Counts the number of personoversikt-status updated from reading topic - isfrisktilarbeid-vedtak-fattet")
+        .description("Counts the number of personoversikt-status updated from reading topic - isfrisktilarbeid-vedtak-status")
         .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/frisktilarbeid/kafka/KafkaFriskTilArbeidTask.kt
+++ b/src/main/kotlin/no/nav/syfo/frisktilarbeid/kafka/KafkaFriskTilArbeidTask.kt
@@ -22,7 +22,7 @@ fun launchKafkaTaskFriskTilArbeidVedtak(
     val consumerProperties = Properties().apply {
         putAll(kafkaAivenConsumerConfig(kafkaEnvironment = kafkaEnvironment))
         this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "10"
-        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = VedtakFattetRecordDeserializer::class.java
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = VedtakStatusRecordDeserializer::class.java
     }
 
     launchKafkaTask(
@@ -33,7 +33,7 @@ fun launchKafkaTaskFriskTilArbeidVedtak(
     )
 }
 
-class VedtakFattetRecordDeserializer : Deserializer<VedtakStatusRecord> {
+class VedtakStatusRecordDeserializer : Deserializer<VedtakStatusRecord> {
     private val mapper = configuredJacksonMapper()
     override fun deserialize(topic: String, data: ByteArray): VedtakStatusRecord =
         mapper.readValue(data, VedtakStatusRecord::class.java)

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
@@ -54,7 +54,7 @@ const val queryHentUbehandledePersonerTilknyttetEnhet = """
                             OR trenger_oppfolging = 't'
                             OR behandler_bistand_ubehandlet = 't'
                             OR arbeidsuforhet_vurder_avslag_ubehandlet = 't'
-                            OR (friskmelding_til_arbeidsformidling_fom IS NOT NULL AND friskmelding_til_arbeidsformidling_fom >= CURRENT_DATE)
+                            OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
                             )
                         );
                 """

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -73,7 +73,7 @@ fun PersonOversiktStatus.hasActiveOppgave(arenaCutoff: LocalDate): Boolean {
         (this.motebehovUbehandlet == true && this.latestOppfolgingstilfelle != null) ||
         this.isActiveAktivitetskrav(arenaCutoff = arenaCutoff) ||
         this.hasActiveBehandlerdialogOppgave() ||
-        this.hasFriskmeldingTilArbeidsformidling() ||
+        this.friskmeldingTilArbeidsformidlingFom != null ||
         this.aktivitetskravVurderStansUbehandlet ||
         this.trengerOppfolging || this.behandlerBerOmBistandUbehandlet || this.arbeidsuforhetVurderAvslagUbehandlet
 }
@@ -127,9 +127,6 @@ fun PersonOversiktStatus.hasActiveBehandlerdialogOppgave(): Boolean {
         this.behandlerdialogUbesvartUbehandlet ||
         this.behandlerdialogAvvistUbehandlet
 }
-
-private fun PersonOversiktStatus.hasFriskmeldingTilArbeidsformidling(): Boolean =
-    this.friskmeldingTilArbeidsformidlingFom != null && LocalDate.now().isBeforeOrEqual(this.friskmeldingTilArbeidsformidlingFom)
 
 fun PersonOversiktStatus.applyHendelse(
     oversikthendelseType: OversikthendelseType,

--- a/src/main/resources/db/migration/V16_4__adjust_frisktilarbeid_index.sql
+++ b/src/main/resources/db/migration/V16_4__adjust_frisktilarbeid_index.sql
@@ -1,0 +1,19 @@
+DROP INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT;
+DROP INDEX IX_PERSON_OVERSIKT_FTA_FOM;
+
+CREATE INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT
+    ON PERSON_OVERSIKT_STATUS (tildelt_enhet, dialogmotekandidat_generated_at)
+    WHERE (motebehov_ubehandlet
+               OR oppfolgingsplan_lps_bistand_ubehandlet
+               OR dialogmotesvar_ubehandlet
+               OR dialogmotekandidat
+               OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT') AND aktivitetskrav_stoppunkt > '2023-03-10')
+               OR behandlerdialog_svar_ubehandlet
+               OR behandlerdialog_ubesvart_ubehandlet
+               OR behandlerdialog_avvist_ubehandlet
+               OR aktivitetskrav_vurder_stans_ubehandlet
+               OR trenger_oppfolging
+               OR behandler_bistand_ubehandlet
+               OR arbeidsuforhet_vurder_avslag_ubehandlet
+               OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
+    );

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -589,10 +589,11 @@ object PersonoversiktStatusApiV2Spek : Spek({
                 }
                 it("return person with friskmelding til arbeidsformidling starting tomorrow") {
                     val personident = PersonIdent(ARBEIDSTAKER_FNR)
+                    val tomorrow = LocalDate.now().plusDays(1)
                     with(database) {
                         createPersonOversiktStatus(PersonOversiktStatus(personident.value))
                         setTildeltEnhet(personident, NAV_ENHET)
-                        setFriskmeldingTilArbeidsformidlingFom(personident, LocalDate.now().plusDays(1))
+                        setFriskmeldingTilArbeidsformidlingFom(personident, tomorrow)
                     }
 
                     with(
@@ -606,15 +607,16 @@ object PersonoversiktStatusApiV2Spek : Spek({
                             objectMapper.readValue<List<PersonOversiktStatusDTO>>(response.content!!).first()
                         personOversiktStatus.fnr shouldBeEqualTo personident.value
                         personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
-                        personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeAfter LocalDate.now()
+                        personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo tomorrow
                     }
                 }
                 it("return person with friskmelding til arbeidsformidling starting today") {
                     val personident = PersonIdent(ARBEIDSTAKER_FNR)
+                    val today = LocalDate.now()
                     with(database) {
                         createPersonOversiktStatus(PersonOversiktStatus(personident.value))
                         setTildeltEnhet(personident, NAV_ENHET)
-                        setFriskmeldingTilArbeidsformidlingFom(personident, LocalDate.now())
+                        setFriskmeldingTilArbeidsformidlingFom(personident, today)
                     }
 
                     with(
@@ -628,22 +630,27 @@ object PersonoversiktStatusApiV2Spek : Spek({
                             objectMapper.readValue<List<PersonOversiktStatusDTO>>(response.content!!).first()
                         personOversiktStatus.fnr shouldBeEqualTo personident.value
                         personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
-                        personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo LocalDate.now()
+                        personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo today
                     }
                 }
-                it("does not return person with friskmelding til arbeidsformidling starting yesterday") {
+                it("return person with friskmelding til arbeidsformidling starting yesterday") {
                     val personident = PersonIdent(ARBEIDSTAKER_FNR)
+                    val yesterday = LocalDate.now().minusDays(1)
                     with(database) {
                         createPersonOversiktStatus(PersonOversiktStatus(personident.value))
                         setTildeltEnhet(personident, NAV_ENHET)
-                        setFriskmeldingTilArbeidsformidlingFom(personident, LocalDate.now().minusDays(1))
+                        setFriskmeldingTilArbeidsformidlingFom(personident, yesterday)
                     }
                     with(
                         handleRequest(HttpMethod.Get, url) {
                             addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
                         }
                     ) {
-                        response.status() shouldBeEqualTo HttpStatusCode.NoContent
+                        val personOversiktStatus =
+                            objectMapper.readValue<List<PersonOversiktStatusDTO>>(response.content!!).first()
+                        personOversiktStatus.fnr shouldBeEqualTo personident.value
+                        personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                        personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo yesterday
                     }
                 }
 


### PR DESCRIPTION
Hente ut personer til oversikten som har `friskmelding_til_arbeidsformidling_fom` satt. Datoen vil nulles ut når vedtaket ferdigbehandles i Modia.
