### PR TITLE
IS-2271: Add column to keep track of arbeidsuforhet vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
@@ -70,7 +70,8 @@ const val queryGetPersonerWithOppgaveAndOldEnhet =
         OR trenger_oppfolging = 't'
         OR behandler_bistand_ubehandlet = 't'
         OR arbeidsuforhet_vurder_avslag_ubehandlet = 't'
-        OR friskmelding_til_arbeidsformidling_fom IS NOT NULL 
+        OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
+        OR arbeidsuforhet_aktiv_vurdering = 't'
         )
     AND (tildelt_enhet_updated_at IS NULL OR tildelt_enhet_updated_at <= NOW() - INTERVAL '24 HOURS')
     ORDER BY tildelt_enhet_updated_at ASC

--- a/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
@@ -44,6 +44,7 @@ const val queryPersonOppfolgingstilfelleVirksomhetNoVirksomhetsnavnList =
         OR behandler_bistand_ubehandlet = 't'
         OR arbeidsuforhet_vurder_avslag_ubehandlet = 't'
         OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
+        OR arbeidsuforhet_aktiv_vurdering = 't'
         )
     ORDER BY PERSON_OPPFOLGINGSTILFELLE_VIRKSOMHET.created_at ASC
     LIMIT 1000

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
@@ -54,6 +54,7 @@ const val queryHentUbehandledePersonerTilknyttetEnhet = """
                             OR trenger_oppfolging = 't'
                             OR behandler_bistand_ubehandlet = 't'
                             OR arbeidsuforhet_vurder_avslag_ubehandlet = 't'
+                            OR arbeidsuforhet_aktiv_vurdering = 't'
                             OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
                             )
                         );

--- a/src/main/resources/db/migration/V16_5__add_column_arbeidsuforhet_aktiv_vurdering.sql
+++ b/src/main/resources/db/migration/V16_5__add_column_arbeidsuforhet_aktiv_vurdering.sql
@@ -1,0 +1,21 @@
+ALTER TABLE person_oversikt_status
+    ADD COLUMN arbeidsuforhet_aktiv_vurdering BOOLEAN DEFAULT FALSE;
+
+DROP INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT;
+
+CREATE INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT
+    ON PERSON_OVERSIKT_STATUS (tildelt_enhet, dialogmotekandidat_generated_at)
+    WHERE (motebehov_ubehandlet
+        OR oppfolgingsplan_lps_bistand_ubehandlet
+        OR dialogmotesvar_ubehandlet
+        OR dialogmotekandidat
+        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT') AND aktivitetskrav_stoppunkt > '2023-03-10')
+        OR behandlerdialog_svar_ubehandlet
+        OR behandlerdialog_ubesvart_ubehandlet
+        OR behandlerdialog_avvist_ubehandlet
+        OR aktivitetskrav_vurder_stans_ubehandlet
+        OR trenger_oppfolging
+        OR behandler_bistand_ubehandlet
+        OR arbeidsuforhet_vurder_avslag_ubehandlet
+        OR arbeidsuforhet_aktiv_vurdering
+        );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til kolonne som holder styr på om det finnes en aktiv 8-4 (arbeidsuforhet) vurdering. Skal brukes til å bestemme om vi skal hente domenedata fra `isarbeidsuforhet`. 

Se trellolapp for mer info