### PR TITLE
IS-2454: Add IKKE_AKTUELL arbeidsuforhet vurdering type

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/arbeidsuforhet/ArbeidsuforhetvurderingDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/arbeidsuforhet/ArbeidsuforhetvurderingDTO.kt
@@ -22,5 +22,5 @@ data class VarselDTO(
 )
 
 enum class VurderingType {
-    FORHANDSVARSEL, OPPFYLT, AVSLAG
+    FORHANDSVARSEL, OPPFYLT, AVSLAG, IKKE_AKTUELL
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingRecord.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingRecord.kt
@@ -16,5 +16,5 @@ data class ArbeidsuforhetvurderingRecord(
 )
 
 enum class VurderingType {
-    FORHANDSVARSEL, OPPFYLT, AVSLAG
+    FORHANDSVARSEL, OPPFYLT, AVSLAG, IKKE_AKTUELL
 }


### PR DESCRIPTION
Litt kjedelig at det må oppdateres to steder siden den er definert både der vi har DTOen vi henter fra isarbeidsuforhet-api og for kafka-recorden. Noen som har forslag til passende sted å samle det? Eventuelt kunne vi fjernet det fra kafka-recorden siden vi ikke bruker det til noe der :man_shrugging: 