### PR TITLE
IS-2497: Inkluderer status NY_VURDERING for aktivitetskrav ved henting av personer til oversikten

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/getFromPersonOversiktStatus.kt
@@ -44,7 +44,7 @@ const val queryHentUbehandledePersonerTilknyttetEnhet = """
                                 AND dialogmotekandidat_generated_at + INTERVAL '7 DAY' < now()
                                 )
                             OR (
-                                (aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT')
+                                (aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT' OR aktivitetskrav = 'NY_VURDERING')
                                 AND aktivitetskrav_stoppunkt > '2023-03-10'
                                 )
                             OR behandlerdialog_svar_ubehandlet = 't'

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -55,7 +55,7 @@ fun PersonOversiktStatus.hasOpenDialogmoteInvitation() =
 fun PersonOversiktStatus.noOpenDialogmoteInvitation() = !hasOpenDialogmoteInvitation()
 
 fun PersonOversiktStatus.isActiveAktivitetskrav(arenaCutoff: LocalDate) =
-    (aktivitetskrav == AktivitetskravStatus.NY || aktivitetskrav == AktivitetskravStatus.AVVENT) &&
+    (aktivitetskrav == AktivitetskravStatus.NY || aktivitetskrav == AktivitetskravStatus.AVVENT || aktivitetskrav == AktivitetskravStatus.NY_VURDERING) &&
         aktivitetskravStoppunkt?.isAfter(arenaCutoff) ?: false
 
 fun PersonOversiktStatus.hasActiveOppgave(arenaCutoff: LocalDate): Boolean {

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetQuery.kt
@@ -62,7 +62,7 @@ const val queryGetPersonerWithOppgaveAndOldEnhet =
         OR oppfolgingsplan_lps_bistand_ubehandlet = 't' 
         OR dialogmotekandidat = 't' 
         OR dialogmotesvar_ubehandlet = 't'
-        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT') AND aktivitetskrav_stoppunkt > '2023-03-10')
+        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT' OR aktivitetskrav = 'NY_VURDERING') AND aktivitetskrav_stoppunkt > '2023-03-10')
         OR behandlerdialog_svar_ubehandlet = 't'
         OR behandlerdialog_ubesvart_ubehandlet = 't'
         OR behandlerdialog_avvist_ubehandlet = 't'

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnQuery.kt
@@ -35,7 +35,7 @@ const val queryPersonOppfolgingstilfelleVirksomhetNoVirksomhetsnavnList =
         OR oppfolgingsplan_lps_bistand_ubehandlet = 't' 
         OR dialogmotekandidat = 't' 
         OR dialogmotesvar_ubehandlet = 't' 
-        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT') AND aktivitetskrav_stoppunkt > '2023-03-10')
+        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT' OR aktivitetskrav = 'NY_VURDERING') AND aktivitetskrav_stoppunkt > '2023-03-10')
         OR behandlerdialog_svar_ubehandlet = 't'
         OR behandlerdialog_ubesvart_ubehandlet = 't'
         OR behandlerdialog_avvist_ubehandlet = 't'

--- a/src/main/resources/db/migration/V17_2__update_index_enhetens_oversikt.sql
+++ b/src/main/resources/db/migration/V17_2__update_index_enhetens_oversikt.sql
@@ -1,0 +1,19 @@
+DROP INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT;
+
+CREATE INDEX IX_PERSON_OVERSIKT_STATUS_ENHETENS_OVERSIKT
+    ON PERSON_OVERSIKT_STATUS (tildelt_enhet, dialogmotekandidat_generated_at)
+    WHERE (motebehov_ubehandlet
+        OR oppfolgingsplan_lps_bistand_ubehandlet
+        OR dialogmotesvar_ubehandlet
+        OR dialogmotekandidat
+        OR ((aktivitetskrav = 'NY' OR aktivitetskrav = 'AVVENT' OR aktivitetskrav = 'NY_VURDERING') AND aktivitetskrav_stoppunkt > '2023-03-10')
+        OR behandlerdialog_svar_ubehandlet
+        OR behandlerdialog_ubesvart_ubehandlet
+        OR behandlerdialog_avvist_ubehandlet
+        OR aktivitetskrav_vurder_stans_ubehandlet
+        OR trenger_oppfolging
+        OR behandler_bistand_ubehandlet
+        OR arbeidsuforhet_aktiv_vurdering
+        OR friskmelding_til_arbeidsformidling_fom IS NOT NULL
+        OR is_aktiv_sen_oppfolging_kandidat
+    );

--- a/src/test/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatusSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatusSpek.kt
@@ -156,5 +156,15 @@ class PersonOversiktStatusSpek : Spek({
 
             person.isActiveAktivitetskrav(arenaCutoff) shouldBeEqualTo false
         }
+
+        it("return true if AktivitetskravStatus is NY_VURDERING") {
+            val person = aktivitetskravGenerator.generateAktivitetskrav(
+                personIdent = defaultPersonident,
+                status = AktivitetskravStatus.NY_VURDERING,
+                stoppunktAfterCutoff = true,
+            ).toPersonOversiktStatus()
+
+            person.isActiveAktivitetskrav(arenaCutoff) shouldBeEqualTo true
+        }
     }
 })


### PR DESCRIPTION
Raskeste løsning på å få vist de som bare har startet ny vurdering i oversikten. 

Litt relatert til dette og oppgaven som går på å vise personen i oversikten når forhåndsvarsel er sendt så tenker jeg vi videre kan gjøre følgende:
- lage bulk-endepunkt i `isaktivitetskrav` for å hente siste aktivitetskrav (med evt vurdering og varsel) for en liste personer.
- ta i bruk bulk-endepunkt herfra for alle personer med aktivt aktivitetskrav (basert på de reglene og feltene vi har her i dag)

Og hvis det funker bra: 
- lage ny `aktivitetskrav_aktiv_vurdering`-kolonnene som settes i vurdering-konsumenten og i migrereringsscript basert på reglene vi har i spørringen for enhetens oversikt i dag.
- tilpasse spørringene for enhetens oversikt til å bruke nytt felt og slette de andre kolonnene for aktivitetskrav og bruken av disse og heller kalle bulk-endepunkt for det man trenger til visning i oversikten (status, frist).
