### PR TITLE
IS-2596: Include all active aktivitetskrav in api call

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
@@ -76,6 +76,7 @@ class PersonoversiktStatusService(
             callId = callId,
             token = token,
             personStatuser = personStatusOversikt,
+            arenaCutoff = arenaCutoff,
         )
 
         return personStatusOversikt.map { personStatus ->
@@ -94,7 +95,7 @@ class PersonoversiktStatusService(
         }
     }
 
-    private suspend fun getArbeidsuforhetvurderinger(
+    private fun getArbeidsuforhetvurderinger(
         callId: String,
         token: String,
         personStatuser: List<PersonOversiktStatus>,
@@ -114,7 +115,7 @@ class PersonoversiktStatusService(
             }
         }
 
-    private suspend fun getActiveOppfolgingsoppgaver(
+    private fun getActiveOppfolgingsoppgaver(
         callId: String,
         token: String,
         personStatuser: List<PersonOversiktStatus>,
@@ -138,14 +139,15 @@ class PersonoversiktStatusService(
             }
         }
 
-    private suspend fun getActiveAktivitetskravForPersons(
+    private fun getActiveAktivitetskravForPersons(
         callId: String,
         token: String,
         personStatuser: List<PersonOversiktStatus>,
+        arenaCutoff: LocalDate,
     ): Deferred<GetAktivitetskravForPersonsResponseDTO?> =
         CoroutineScope(Dispatchers.IO).async {
             val personidenterWithActiveAktivitetskrav = personStatuser
-                .filter { it.isAktivAktivitetskravvurdering }
+                .filter { it.isAktivAktivitetskravvurdering || it.isActiveAktivitetskrav(arenaCutoff = arenaCutoff) }
                 .map { PersonIdent(it.fnr) }
             if (personidenterWithActiveAktivitetskrav.isNotEmpty()) {
                 aktivitetskravClient.getAktivitetskravForPersons(

--- a/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
@@ -1,11 +1,11 @@
 package no.nav.syfo.testutil
 
 import io.ktor.server.application.*
+import io.mockk.mockk
 import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.api.v2.apiModule
-import no.nav.syfo.personstatus.infrastructure.clients.AktivitetskravClient
 import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ArbeidsuforhetvurderingClient
 import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.OppfolgingsoppgaveClient
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
@@ -32,10 +32,6 @@ fun Application.testApiModule(
         azureAdClient = azureAdClient,
         clientEnvironment = externalMockEnvironment.environment.clients.ishuskelapp,
     )
-    val aktivitetskravClient = AktivitetskravClient(
-        azureAdClient = azureAdClient,
-        clientEnvironment = externalMockEnvironment.environment.clients.aktivitetskrav,
-    )
     val personoversiktRepository = PersonOversiktStatusRepository(database = externalMockEnvironment.database)
     val personoversiktStatusService = PersonoversiktStatusService(
         database = externalMockEnvironment.database,
@@ -43,7 +39,7 @@ fun Application.testApiModule(
         personoversiktStatusRepository = personoversiktRepository,
         arbeidsuforhetvurderingClient = arbeidsuforhetvurderingClient,
         oppfolgingsoppgaveClient = oppfolgingsoppgaveClient,
-        aktivitetskravClient = aktivitetskravClient,
+        aktivitetskravClient = mockk(relaxed = true),
     )
 
     this.apiModule(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Henter siste aktivitetskrav-vurdering fra isaktivitetskrav for alle personer med aktivt aktivitetskrav basert på "gammel" logikk.
Hvis dette kjører fint i prod ytelsesmessig kan vi migrere slik at alle med aktivt aktivitetskrav basert på "gammel" logikk får satt det nye feltet isAktivAktivitetskrav til true og deretter fjerne all bruk av gamle felter.
