### PR TITLE
IS-2679: Start consumer manglende medvirkning

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/manglendemedvirkning/ManglendeMedvirkningDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/manglendemedvirkning/ManglendeMedvirkningDTO.kt
@@ -16,9 +16,10 @@ data class ManglendeMedvirkningDTO(
     val uuid: UUID,
     val personident: String,
     val createdAt: LocalDateTime,
-    val type: ManglendeMedvirkningVurderingType,
+    val vurderingType: ManglendeMedvirkningVurderingType,
     val begrunnelse: String,
     val varsel: ManglendeMedvirkningVarselDTO?,
+    val veilederident: String,
 )
 
 data class ManglendeMedvirkningVarselDTO(
@@ -28,5 +29,5 @@ data class ManglendeMedvirkningVarselDTO(
 )
 
 enum class ManglendeMedvirkningVurderingType {
-    FORHANDSVARSEL, OPPFYLT, STANS, IKKE_AKTUELL,
+    FORHANDSVARSEL, OPPFYLT, STANS, IKKE_AKTUELL, UNNTAK
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaModule.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.oppfolgingstilfelle.kafka.launchKafkaTaskOppfolgingstilfelleP
 import no.nav.syfo.pdlpersonhendelse.kafka.launchKafkaTaskPersonhendelse
 import no.nav.syfo.personoppgavehendelse.kafka.launchKafkaTaskPersonoppgavehendelse
 import no.nav.syfo.personstatus.PersonoversiktStatusService
+import no.nav.syfo.personstatus.infrastructure.kafka.manglendemedvirkning.ManglendeMedvirkningVurderingConsumer
 import no.nav.syfo.personstatus.infrastructure.kafka.meroppfolging.SenOppfolgingKandidatStatusConsumer
 import no.nav.syfo.trengeroppfolging.kafka.launchTrengerOppfolgingConsumer
 
@@ -71,6 +72,12 @@ fun launchKafkaModule(
         .start(applicationState = applicationState, kafkaEnvironment = environment.kafka)
 
     SenOppfolgingKandidatStatusConsumer(personoversiktStatusService = personoversiktStatusService)
+        .start(
+            applicationState = applicationState,
+            kafkaEnvironment = environment.kafka,
+        )
+
+    ManglendeMedvirkningVurderingConsumer(personoversiktStatusService = personoversiktStatusService)
         .start(
             applicationState = applicationState,
             kafkaEnvironment = environment.kafka,

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumer.kt
@@ -2,8 +2,8 @@ package no.nav.syfo.personstatus.infrastructure.kafka.manglendemedvirkning
 
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.personstatus.PersonoversiktStatusService
+import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.infrastructure.kafka.*
-import no.nav.syfo.personstatus.infrastructure.kafka.meroppfolging.KandidatStatusRecord
 import no.nav.syfo.util.configuredJacksonMapper
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecords
@@ -47,7 +47,7 @@ class ManglendeMedvirkningVurderingConsumer(
         return validRecords.map { record ->
             val recordValue = record.value()
             personoversiktStatusService.upsertManglendeMedvirkningStatus(
-                personident = recordValue.personident,
+                personident = PersonIdent(recordValue.personident),
                 isAktivVurdering = recordValue.vurderingType.isActive,
             )
         }
@@ -59,8 +59,8 @@ class ManglendeMedvirkningVurderingConsumer(
     }
 }
 
-class ManglendeMedvirkningVurderingRecordDeserializer : Deserializer<KandidatStatusRecord> {
+class ManglendeMedvirkningVurderingRecordDeserializer : Deserializer<VurderingRecord> {
     private val mapper = configuredJacksonMapper()
-    override fun deserialize(topic: String, data: ByteArray): KandidatStatusRecord =
-        mapper.readValue(data, KandidatStatusRecord::class.java)
+    override fun deserialize(topic: String, data: ByteArray): VurderingRecord =
+        mapper.readValue(data, VurderingRecord::class.java)
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/VurderingRecord.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/VurderingRecord.kt
@@ -1,13 +1,12 @@
 package no.nav.syfo.personstatus.infrastructure.kafka.manglendemedvirkning
 
-import no.nav.syfo.personstatus.domain.PersonIdent
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
 data class VurderingRecord(
     val uuid: UUID,
-    val personident: PersonIdent,
+    val personident: String,
     val veilederident: String,
     val createdAt: OffsetDateTime,
     val begrunnelse: String,
@@ -21,11 +20,11 @@ data class VurderingTypeDTO(
 )
 
 enum class VurderingType {
-    FORHANDSVARSEL, OPPFYLT, STANS, IKKE_AKTUELL
+    FORHANDSVARSEL, OPPFYLT, STANS, IKKE_AKTUELL, UNNTAK
 }
 
 data class Varsel(
     val uuid: UUID,
     val createdAt: OffsetDateTime,
-    val svarFrist: LocalDate,
+    val svarfrist: LocalDate,
 )

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -972,8 +972,9 @@ object PersonoversiktStatusApiV2Spek : Spek({
                             personOversiktStatus.fnr shouldBeEqualTo ARBEIDSTAKER_FNR
                             personOversiktStatus.manglendeMedvirkning shouldNotBe null
                             personOversiktStatus.manglendeMedvirkning?.varsel shouldNotBe null
-                            personOversiktStatus.manglendeMedvirkning?.type shouldBeEqualTo ManglendeMedvirkningVurderingType.FORHANDSVARSEL
+                            personOversiktStatus.manglendeMedvirkning?.vurderingType shouldBeEqualTo ManglendeMedvirkningVurderingType.FORHANDSVARSEL
                             personOversiktStatus.manglendeMedvirkning?.begrunnelse shouldBeEqualTo "begrunnelse"
+                            personOversiktStatus.manglendeMedvirkning?.veilederident shouldBeEqualTo VEILEDER_ID
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
@@ -60,14 +60,14 @@ class ManglendeMedvirkningVurderingConsumerSpek : Spek({
         val personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR)
         val forhandsvarselVurderingRecord = VurderingRecord(
             uuid = UUID.randomUUID(),
-            personident = personident,
+            personident = personident.value,
             veilederident = UserConstants.VEILEDER_ID,
             createdAt = OffsetDateTime.now(),
             begrunnelse = "begrunnelse",
             varsel = Varsel(
                 uuid = UUID.randomUUID(),
                 createdAt = OffsetDateTime.now(),
-                svarFrist = LocalDate.now().plusWeeks(3),
+                svarfrist = LocalDate.now().plusWeeks(3),
             ),
             vurderingType = VurderingTypeDTO(
                 value = VurderingType.FORHANDSVARSEL,

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/ManglendeMedvirkningMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/ManglendeMedvirkningMock.kt
@@ -21,8 +21,9 @@ fun MockRequestHandleScope.manglendeMedvirkningMockResponse(): HttpResponseData 
                         uuid = UUID.randomUUID(),
                         personident = UserConstants.ARBEIDSTAKER_FNR,
                         createdAt = LocalDateTime.now().minusDays(1),
-                        type = ManglendeMedvirkningVurderingType.FORHANDSVARSEL,
+                        vurderingType = ManglendeMedvirkningVurderingType.FORHANDSVARSEL,
                         begrunnelse = "begrunnelse",
+                        veilederident = UserConstants.VEILEDER_ID,
                         varsel = ManglendeMedvirkningVarselDTO(
                             uuid = UUID.randomUUID(),
                             createdAt = LocalDateTime.now().minusDays(1),


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Oppdaget at de brukerne som har forhåndsvarsel på manglende medvirkning ikke dukket opp i oversikten. Vi fant ut at det var flere grunner til dette. For å fikse dette så har vi: 
- Startet consumeren 
- Gjort om personident til string
- Lagt til unntak som vurderingstype
- Fikset opp i copy paste feil, bruker nå vurderingRecord isteden
- Fikset opp i skrivemåte av svarfrist (svarFrist) i recorden
- Oppdaterte manglendeMedvirkningDTO til å passe produseren ved å endre til `vurderingType`, legge til `veilederident`. Har ignorert `document` som også leveres av api-et, men er ikke relevant her. 
