### PR TITLE
Improve test and aktivitetskravClient mock

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -9,9 +9,9 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.api.v2.apiModule
 import no.nav.syfo.personstatus.api.v2.auth.getWellKnown
-import no.nav.syfo.personstatus.infrastructure.clients.AktivitetskravClient
+import no.nav.syfo.personstatus.infrastructure.clients.aktivitetskrav.AktivitetskravClient
 import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ArbeidsuforhetvurderingClient
-import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ManglendeMedvirkningClient
+import no.nav.syfo.personstatus.infrastructure.clients.manglendemedvirkning.ManglendeMedvirkningClient
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.OppfolgingsoppgaveClient

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
@@ -10,8 +10,8 @@ import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personoppgavehendelse.kafka.*
 import no.nav.syfo.personstatus.api.v2.model.PersonOversiktStatusDTO
-import no.nav.syfo.personstatus.application.GetAktivitetskravForPersonsResponseDTO
-import no.nav.syfo.personstatus.application.IAktivitetskravClient
+import no.nav.syfo.personstatus.application.aktivitetskrav.GetAktivitetskravForPersonsResponseDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.IAktivitetskravClient
 import no.nav.syfo.personstatus.application.IPersonOversiktStatusRepository
 import no.nav.syfo.personstatus.application.arbeidsuforhet.ArbeidsuforhetvurderingerResponseDTO
 import no.nav.syfo.personstatus.application.arbeidsuforhet.IArbeidsuforhetvurderingClient

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
@@ -50,7 +50,7 @@ class PersonoversiktStatusService(
                 ?: emptyList()
             it.toPersonOversiktStatus(personOppfolgingstilfelleVirksomhetList)
         }.filter { personOversiktStatus ->
-            personOversiktStatus.hasActiveOppgave() // TODO: Trenger vi denne når db-spørringen henter ut bare aktive personer?
+            personOversiktStatus.hasActiveOppgave()
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/api/v2/model/PersonOversiktStatusDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/api/v2/model/PersonOversiktStatusDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.personstatus.api.v2.model
 
-import no.nav.syfo.personstatus.application.AktivitetskravDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravDTO
 import no.nav.syfo.personstatus.application.arbeidsuforhet.ArbeidsuforhetvurderingDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningDTO
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveDTO

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/aktivitetskrav/AktivitetskravDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/aktivitetskrav/AktivitetskravDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus.application
+package no.nav.syfo.personstatus.application.aktivitetskrav
 
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/aktivitetskrav/IAktivitetskravClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/aktivitetskrav/IAktivitetskravClient.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus.application
+package no.nav.syfo.personstatus.application.aktivitetskrav
 
 import no.nav.syfo.personstatus.domain.PersonIdent
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -4,7 +4,7 @@ import no.nav.syfo.dialogmotestatusendring.domain.DialogmoteStatusendringType
 import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
 import no.nav.syfo.oppfolgingstilfelle.domain.toPersonOppfolgingstilfelleDTO
 import no.nav.syfo.personstatus.api.v2.model.PersonOversiktStatusDTO
-import no.nav.syfo.personstatus.application.AktivitetskravDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravDTO
 import no.nav.syfo.personstatus.application.arbeidsuforhet.ArbeidsuforhetvurderingDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningDTO
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveDTO

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/aktivitetskrav/AktivitetskravClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/aktivitetskrav/AktivitetskravClient.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus.infrastructure.clients
+package no.nav.syfo.personstatus.infrastructure.clients.aktivitetskrav
 
 import io.ktor.client.*
 import io.ktor.client.call.body
@@ -12,10 +12,12 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.*
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.personstatus.domain.PersonIdent
-import no.nav.syfo.personstatus.application.AktivitetskravRequestDTO
-import no.nav.syfo.personstatus.application.GetAktivitetskravForPersonsResponseDTO
-import no.nav.syfo.personstatus.application.IAktivitetskravClient
+import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravRequestDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.GetAktivitetskravForPersonsResponseDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.IAktivitetskravClient
+import no.nav.syfo.personstatus.infrastructure.clients.ClientEnvironment
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
+import no.nav.syfo.personstatus.infrastructure.clients.httpClientDefault
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 import no.nav.syfo.util.bearerHeader
 import no.nav.syfo.util.callIdArgument

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/manglendemedvirkning/ManglendeMedvirkningClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/manglendemedvirkning/ManglendeMedvirkningClient.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet
+package no.nav.syfo.personstatus.infrastructure.clients.manglendemedvirkning
 
 import io.ktor.client.*
 import io.ktor.client.call.*

--- a/src/test/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/AktivitetskravVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/AktivitetskravVurderingConsumerSpek.kt
@@ -5,7 +5,7 @@ import io.mockk.*
 import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
 import no.nav.syfo.oppfolgingstilfelle.kafka.toPersonOversiktStatus
 import no.nav.syfo.personstatus.PersonoversiktStatusService
-import no.nav.syfo.personstatus.application.IAktivitetskravClient
+import no.nav.syfo.personstatus.application.aktivitetskrav.IAktivitetskravClient
 import no.nav.syfo.personstatus.application.arbeidsuforhet.IArbeidsuforhetvurderingClient
 import no.nav.syfo.personstatus.application.manglendemedvirkning.IManglendeMedvirkningClient
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.IOppfolgingsoppgaveClient

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -1004,6 +1004,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                                 objectMapper.readValue<List<PersonOversiktStatusDTO>>(response.content!!).first()
                             personOversiktStatus.fnr shouldBeEqualTo personident
                             personOversiktStatus.enhet shouldBeEqualTo NAV_ENHET
+                            personOversiktStatus.aktivitetskravvurdering shouldNotBe null
                         }
                     }
 

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingConsumerSpek.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.PersonoversiktStatusService
-import no.nav.syfo.personstatus.application.IAktivitetskravClient
+import no.nav.syfo.personstatus.application.aktivitetskrav.IAktivitetskravClient
 import no.nav.syfo.personstatus.application.arbeidsuforhet.IArbeidsuforhetvurderingClient
 import no.nav.syfo.personstatus.application.manglendemedvirkning.IManglendeMedvirkningClient
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.IOppfolgingsoppgaveClient

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.syfo.personstatus.PersonoversiktStatusService
-import no.nav.syfo.personstatus.application.IAktivitetskravClient
+import no.nav.syfo.personstatus.application.aktivitetskrav.IAktivitetskravClient
 import no.nav.syfo.personstatus.application.arbeidsuforhet.IArbeidsuforhetvurderingClient
 import no.nav.syfo.personstatus.application.manglendemedvirkning.IManglendeMedvirkningClient
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.IOppfolgingsoppgaveClient

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumerSpek.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.syfo.personstatus.PersonoversiktStatusService
-import no.nav.syfo.personstatus.application.IAktivitetskravClient
+import no.nav.syfo.personstatus.application.aktivitetskrav.IAktivitetskravClient
 import no.nav.syfo.personstatus.application.arbeidsuforhet.IArbeidsuforhetvurderingClient
 import no.nav.syfo.personstatus.application.manglendemedvirkning.IManglendeMedvirkningClient
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.IOppfolgingsoppgaveClient

--- a/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
@@ -9,9 +9,9 @@ import no.nav.syfo.personstatus.infrastructure.cronjob.behandlendeenhet.PersonBe
 import no.nav.syfo.personstatus.infrastructure.cronjob.virksomhetsnavn.PersonOppfolgingstilfelleVirksomhetnavnCronjob
 import no.nav.syfo.personstatus.infrastructure.cronjob.virksomhetsnavn.PersonOppfolgingstilfelleVirksomhetsnavnService
 import no.nav.syfo.personstatus.PersonoversiktStatusService
-import no.nav.syfo.personstatus.infrastructure.clients.AktivitetskravClient
+import no.nav.syfo.personstatus.infrastructure.clients.aktivitetskrav.AktivitetskravClient
 import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ArbeidsuforhetvurderingClient
-import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ManglendeMedvirkningClient
+import no.nav.syfo.personstatus.infrastructure.clients.manglendemedvirkning.ManglendeMedvirkningClient
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.OppfolgingsoppgaveClient
 import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository

--- a/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
@@ -1,11 +1,11 @@
 package no.nav.syfo.testutil
 
 import io.ktor.server.application.*
-import io.mockk.mockk
 import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.api.v2.apiModule
+import no.nav.syfo.personstatus.infrastructure.clients.AktivitetskravClient
 import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ArbeidsuforhetvurderingClient
 import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ManglendeMedvirkningClient
 import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.OppfolgingsoppgaveClient
@@ -43,6 +43,11 @@ fun Application.testApiModule(
         clientEnvironment = externalMockEnvironment.environment.clients.ishuskelapp,
         httpClient = externalMockEnvironment.mockHttpClient
     )
+    val aktivitetskravClient = AktivitetskravClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = externalMockEnvironment.environment.clients.aktivitetskrav,
+        httpClient = externalMockEnvironment.mockHttpClient
+    )
     val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
         azureAdClient = azureAdClient,
         istilgangskontrollEnv = externalMockEnvironment.environment.clients.istilgangskontroll,
@@ -56,7 +61,7 @@ fun Application.testApiModule(
         arbeidsuforhetvurderingClient = arbeidsuforhetvurderingClient,
         manglendeMedvirkningClient = manglendeMedvirkningClient,
         oppfolgingsoppgaveClient = oppfolgingsoppgaveClient,
-        aktivitetskravClient = mockk(relaxed = true),
+        aktivitetskravClient = aktivitetskravClient,
     )
 
     this.apiModule(

--- a/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
@@ -5,9 +5,9 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.api.v2.apiModule
-import no.nav.syfo.personstatus.infrastructure.clients.AktivitetskravClient
+import no.nav.syfo.personstatus.infrastructure.clients.aktivitetskrav.AktivitetskravClient
 import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ArbeidsuforhetvurderingClient
-import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.ManglendeMedvirkningClient
+import no.nav.syfo.personstatus.infrastructure.clients.manglendemedvirkning.ManglendeMedvirkningClient
 import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.OppfolgingsoppgaveClient
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.personstatus.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/AktivitetskravMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/AktivitetskravMock.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.testutil.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.personstatus.application.AktivitetskravDTO
+import no.nav.syfo.personstatus.application.AktivitetskravStatus
+import no.nav.syfo.personstatus.application.GetAktivitetskravForPersonsResponseDTO
+import no.nav.syfo.testutil.UserConstants
+import java.time.LocalDateTime
+import java.util.UUID
+
+fun MockRequestHandleScope.aktivitetskravMockResponse(): HttpResponseData =
+    respondOk(
+        GetAktivitetskravForPersonsResponseDTO(
+            mapOf(
+                Pair(
+                    UserConstants.ARBEIDSTAKER_FNR,
+                    AktivitetskravDTO(
+                        uuid = UUID.randomUUID().toString(),
+                        createdAt = LocalDateTime.now(),
+                        status = AktivitetskravStatus.NY,
+                        vurderinger = emptyList(),
+                    ),
+                ),
+            ),
+        )
+    )

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/AktivitetskravMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/AktivitetskravMock.kt
@@ -2,9 +2,9 @@ package no.nav.syfo.testutil.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import no.nav.syfo.personstatus.application.AktivitetskravDTO
-import no.nav.syfo.personstatus.application.AktivitetskravStatus
-import no.nav.syfo.personstatus.application.GetAktivitetskravForPersonsResponseDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravDTO
+import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravStatus
+import no.nav.syfo.personstatus.application.aktivitetskrav.GetAktivitetskravForPersonsResponseDTO
 import no.nav.syfo.testutil.UserConstants
 import java.time.LocalDateTime
 import java.util.UUID

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/MockHttpClient.kt
@@ -23,6 +23,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
                 requestUrl.startsWith("/${environment.clients.arbeidsuforhetvurdering.baseUrl}") -> arbeidsuforhetVurderingMockResponse()
                 requestUrl.startsWith("/${environment.clients.ishuskelapp.baseUrl}") -> oppfolgingsoppgaveMockResponse()
                 requestUrl.startsWith("/${environment.clients.manglendeMedvirkning.baseUrl}") -> manglendeMedvirkningMockResponse()
+                requestUrl.startsWith("/${environment.clients.aktivitetskrav.baseUrl}") -> aktivitetskravMockResponse()
 
                 else -> error("Unhandled ${request.url.encodedPath}")
             }


### PR DESCRIPTION
Lagt til sjekk på aktivitetskrav-vurdering i api-test og lagt til manglende mock for `aktivitetskravClient` slik at testen passerer.
Flyttet også aktivitetskrav-filer til egne mapper slik at strukturen blir mer lik andre clients.
