### PR TITLE
IS-2711: Veileder historikk

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -121,6 +121,8 @@ fun main() {
                     arbeidsuforhetvurderingClient = arbeidsuforhetvurderingClient,
                     merOppfolgingClient = merOppfolgingClient,
                 ),
+                personBehandlendeEnhetService = personBehandlendeEnhetService,
+                personoversiktStatusRepository = personoversiktStatusRepository,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.personstatus
 
 import no.nav.syfo.personstatus.application.IPersonOversiktStatusRepository
 import no.nav.syfo.personstatus.domain.PersonIdent
+import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import no.nav.syfo.personstatus.domain.VeilederBrukerKnytning
 import no.nav.syfo.personstatus.infrastructure.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 
@@ -15,9 +16,11 @@ class PersonTildelingService(
     ) {
         veilederBrukerKnytninger.forEach {
             val personident = PersonIdent(it.fnr)
-            val personoversiktStatus = personoversiktStatusRepository.getOrCreatePersonOversiktStatusIfMissing(
-                personident = personident,
-            )
+            val personoversiktStatus = personoversiktStatusRepository.getPersonOversiktStatus(personident)
+                ?: PersonOversiktStatus(fnr = it.fnr).also { personOversiktStatus ->
+                    personoversiktStatusRepository.createPersonOversiktStatus(personOversiktStatus)
+                }
+
             if (personoversiktStatus.enhet == null) {
                 personBehandlendeEnhetService.updateBehandlendeEnhet(personident)
             }

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
@@ -14,9 +14,11 @@ class PersonTildelingService(
         tildeltAv: String,
     ) {
         veilederBrukerKnytninger.map {
-            val personoversiktCreated = personoversiktStatusRepository.createPersonOversiktStatusIfMissing(PersonIdent(it.fnr))
-            if (personoversiktCreated) {
-                personBehandlendeEnhetService.updateBehandlendeEnhet(PersonIdent(it.fnr))
+            val personident = PersonIdent(it.fnr)
+            personoversiktStatusRepository.createPersonOversiktStatusIfMissing(personident)
+            val personoversiktStatus = personoversiktStatusRepository.getPersonOversiktStatus(personident)
+            if (personoversiktStatus!!.enhet == null) {
+                personBehandlendeEnhetService.updateBehandlendeEnhet(personident)
             }
             personoversiktStatusRepository.lagreVeilederForBruker(
                 veilederBrukerKnytning = it,

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
@@ -1,11 +1,27 @@
 package no.nav.syfo.personstatus
 
-import no.nav.syfo.personstatus.infrastructure.database.DatabaseInterface
-import no.nav.syfo.personstatus.db.lagreVeilederForBruker
+import no.nav.syfo.personstatus.application.IPersonOversiktStatusRepository
+import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.domain.VeilederBrukerKnytning
+import no.nav.syfo.personstatus.infrastructure.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 
-class PersonTildelingService(private val database: DatabaseInterface) {
-
-    fun lagreKnytningMellomVeilederOgBruker(veilederBrukerKnytninger: List<VeilederBrukerKnytning>) =
-        veilederBrukerKnytninger.map { database.lagreVeilederForBruker(it) }
+class PersonTildelingService(
+    private val personoversiktStatusRepository: IPersonOversiktStatusRepository,
+    private val personBehandlendeEnhetService: PersonBehandlendeEnhetService,
+) {
+    suspend fun lagreKnytningMellomVeilederOgBruker(
+        veilederBrukerKnytninger: List<VeilederBrukerKnytning>,
+        tildeltAv: String,
+    ) {
+        veilederBrukerKnytninger.map {
+            val personoversiktCreated = personoversiktStatusRepository.createPersonOversiktStatusIfMissing(PersonIdent(it.fnr))
+            if (personoversiktCreated) {
+                personBehandlendeEnhetService.updateBehandlendeEnhet(PersonIdent(it.fnr))
+            }
+            personoversiktStatusRepository.lagreVeilederForBruker(
+                veilederBrukerKnytning = it,
+                tildeltAv = tildeltAv,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonTildelingService.kt
@@ -13,11 +13,12 @@ class PersonTildelingService(
         veilederBrukerKnytninger: List<VeilederBrukerKnytning>,
         tildeltAv: String,
     ) {
-        veilederBrukerKnytninger.map {
+        veilederBrukerKnytninger.forEach {
             val personident = PersonIdent(it.fnr)
-            personoversiktStatusRepository.createPersonOversiktStatusIfMissing(personident)
-            val personoversiktStatus = personoversiktStatusRepository.getPersonOversiktStatus(personident)
-            if (personoversiktStatus!!.enhet == null) {
+            val personoversiktStatus = personoversiktStatusRepository.getOrCreatePersonOversiktStatusIfMissing(
+                personident = personident,
+            )
+            if (personoversiktStatus.enhet == null) {
                 personBehandlendeEnhetService.updateBehandlendeEnhet(personident)
             }
             personoversiktStatusRepository.lagreVeilederForBruker(

--- a/src/main/kotlin/no/nav/syfo/personstatus/api/v2/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/api/v2/ApiModule.kt
@@ -22,6 +22,8 @@ import no.nav.syfo.personstatus.api.v2.auth.JwtIssuerType
 import no.nav.syfo.personstatus.api.v2.auth.WellKnown
 import no.nav.syfo.personstatus.api.v2.endpoints.registerPersonTildelingApiV2
 import no.nav.syfo.personstatus.api.v2.endpoints.registerPersonoversiktApiV2
+import no.nav.syfo.personstatus.application.IPersonOversiktStatusRepository
+import no.nav.syfo.personstatus.infrastructure.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 
 fun Application.apiModule(
     applicationState: ApplicationState,
@@ -31,6 +33,8 @@ fun Application.apiModule(
     personoversiktStatusService: PersonoversiktStatusService,
     tilgangskontrollClient: VeilederTilgangskontrollClient,
     personoversiktOppgaverService: PersonoversiktOppgaverService,
+    personBehandlendeEnhetService: PersonBehandlendeEnhetService,
+    personoversiktStatusRepository: IPersonOversiktStatusRepository,
 ) {
     installCallId()
     installContentNegotiation()
@@ -48,7 +52,8 @@ fun Application.apiModule(
     )
 
     val personTildelingService = PersonTildelingService(
-        database = database,
+        personoversiktStatusRepository = personoversiktStatusRepository,
+        personBehandlendeEnhetService = personBehandlendeEnhetService,
     )
 
     routing {

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -16,7 +16,7 @@ interface IPersonOversiktStatusRepository {
 
     fun getPersonOversiktStatus(personident: PersonIdent): PersonOversiktStatus?
 
-    fun createPersonOversiktStatusIfMissing(personident: PersonIdent)
+    fun getOrCreatePersonOversiktStatusIfMissing(personident: PersonIdent): PersonOversiktStatus
 
     fun lagreVeilederForBruker(
         veilederBrukerKnytning: VeilederBrukerKnytning,

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.personstatus.application
 
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus
+import no.nav.syfo.personstatus.domain.VeilederBrukerKnytning
 
 interface IPersonOversiktStatusRepository {
 
@@ -14,4 +15,11 @@ interface IPersonOversiktStatusRepository {
     fun upsertManglendeMedvirkningStatus(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int>
 
     fun getPersonOversiktStatus(personident: PersonIdent): PersonOversiktStatus?
+
+    fun createPersonOversiktStatusIfMissing(personident: PersonIdent): Boolean
+
+    fun lagreVeilederForBruker(
+        veilederBrukerKnytning: VeilederBrukerKnytning,
+        tildeltAv: String,
+    )
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -16,7 +16,7 @@ interface IPersonOversiktStatusRepository {
 
     fun getPersonOversiktStatus(personident: PersonIdent): PersonOversiktStatus?
 
-    fun getOrCreatePersonOversiktStatusIfMissing(personident: PersonIdent): PersonOversiktStatus
+    fun createPersonOversiktStatus(personOversiktStatus: PersonOversiktStatus)
 
     fun lagreVeilederForBruker(
         veilederBrukerKnytning: VeilederBrukerKnytning,

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -16,7 +16,7 @@ interface IPersonOversiktStatusRepository {
 
     fun getPersonOversiktStatus(personident: PersonIdent): PersonOversiktStatus?
 
-    fun createPersonOversiktStatusIfMissing(personident: PersonIdent): Boolean
+    fun createPersonOversiktStatusIfMissing(personident: PersonIdent)
 
     fun lagreVeilederForBruker(
         veilederBrukerKnytning: VeilederBrukerKnytning,

--- a/src/main/kotlin/no/nav/syfo/personstatus/db/createOrUpdatePersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/db/createOrUpdatePersonOversiktStatus.kt
@@ -167,39 +167,6 @@ fun Connection.updatePersonOversiktStatusOppfolgingstilfelle(
     )
 }
 
-const val updateTildeltVeilederQuery =
-    """
-         UPDATE PERSON_OVERSIKT_STATUS
-         SET tildelt_veileder = ?, sist_endret = ?
-         WHERE fnr = ?
-    """
-
-fun DatabaseInterface.lagreVeilederForBruker(veilederBrukerKnytning: VeilederBrukerKnytning) {
-    val rowCount = this.connection.use { connection ->
-        connection.prepareStatement(updateTildeltVeilederQuery).use {
-            it.setString(1, veilederBrukerKnytning.veilederIdent)
-            it.setObject(2, Timestamp.from(Instant.now()))
-            it.setString(3, veilederBrukerKnytning.fnr)
-            it.executeUpdate()
-        }.also {
-            connection.commit()
-        }
-    }
-
-    if (rowCount == 0) {
-        val personOversiktStatus = PersonOversiktStatus(
-            veilederIdent = veilederBrukerKnytning.veilederIdent,
-            fnr = veilederBrukerKnytning.fnr,
-        )
-        this.connection.use { connection ->
-            connection.createPersonOversiktStatus(
-                commit = true,
-                personOversiktStatus = personOversiktStatus,
-            )
-        }
-    }
-}
-
 const val queryUpdatePersonOversiktStatusNavn =
     """
     UPDATE PERSON_OVERSIKT_STATUS

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/VeilederBrukerKnytningListe.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/VeilederBrukerKnytningListe.kt
@@ -1,5 +1,5 @@
 package no.nav.syfo.personstatus.domain
 
 data class VeilederBrukerKnytningListe(
-    val tilknytninger: ArrayList<VeilederBrukerKnytning>
+    val tilknytninger: List<VeilederBrukerKnytning>
 )

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetService.kt
@@ -14,7 +14,7 @@ class PersonBehandlendeEnhetService(
 
     suspend fun updateBehandlendeEnhet(
         personIdent: PersonIdent,
-        tildeltEnhet: String?,
+        tildeltEnhet: String? = null,
     ) {
         val maybeNewBehandlendeEnhet = behandlendeEnhetClient.getEnhet(
             callId = UUID.randomUUID().toString(),

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -302,7 +302,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         const val CREATE_VEILEDER_HISTORIKK =
             """
             INSERT INTO VEILEDER_HISTORIKK (
-                id,uuid,person_oversikt_status_id,fra_dato,tildelt_veileder,tildelt_enhet,tildelt_av
+                id,uuid,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av
             ) VALUES(DEFAULT,?,?,?,?,?,?)
             """
     }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -166,7 +166,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             if (existingVeilederAndEnhet == null) {
                 throw SQLException("lagreVeilederForBruker failed, no existing personoversiktStatus found.")
             } else if (existingVeilederAndEnhet.veileder != veilederBrukerKnytning.veilederIdent) {
-                connection.updateVeileder(veilederBrukerKnytning, existingVeilederAndEnhet)
+                connection.updateVeileder(existingVeilederAndEnhet, veilederBrukerKnytning)
                 connection.addVeilederHistorikk(existingVeilederAndEnhet, veilederBrukerKnytning, tildeltAv)
                 connection.commit()
             }
@@ -186,8 +186,8 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         }.firstOrNull()
 
     private fun Connection.updateVeileder(
-        veilederBrukerKnytning: VeilederBrukerKnytning,
         existingVeilederAndEnhet: VeilederAndEnhet,
+        veilederBrukerKnytning: VeilederBrukerKnytning,
     ) {
         val rowCount = this.prepareStatement(UPDATE_TILDELT_VEILEDER_QUERY).use {
             it.setString(1, veilederBrukerKnytning.veilederIdent)
@@ -302,7 +302,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             WHERE id = ?
             """
 
-        const val CREATE_VEILEDER_HISTORIKK =
+        private const val CREATE_VEILEDER_HISTORIKK =
             """
             INSERT INTO VEILEDER_HISTORIKK (
                 id,uuid,created_at,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -145,13 +145,12 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         return personoversiktStatus.firstOrNull()?.toPersonOversiktStatus()
     }
 
-    override fun createPersonOversiktStatusIfMissing(personident: PersonIdent): Boolean {
+    override fun createPersonOversiktStatusIfMissing(personident: PersonIdent) {
         database.connection.use { connection ->
             val missing = (connection.getPersonOversiktStatus(personident) == null)
             if (missing) {
                 connection.createPersonOversiktStatus(true, PersonOversiktStatus(fnr = personident.value))
             }
-            return missing
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -1,14 +1,15 @@
 package no.nav.syfo.personstatus.infrastructure.database.repository
 
-import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.application.IPersonOversiktStatusRepository
-import no.nav.syfo.personstatus.domain.PPersonOversiktStatus
-import no.nav.syfo.personstatus.domain.PersonOversiktStatus
-import no.nav.syfo.personstatus.domain.toPersonOversiktStatus
+import no.nav.syfo.personstatus.db.*
+import no.nav.syfo.personstatus.domain.*
 import no.nav.syfo.personstatus.infrastructure.database.DatabaseInterface
 import no.nav.syfo.personstatus.infrastructure.database.toList
 import java.lang.RuntimeException
+import java.sql.Connection
+import java.sql.Date
 import java.sql.ResultSet
+import java.sql.SQLException
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
@@ -131,12 +132,85 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
     }
 
     override fun getPersonOversiktStatus(personident: PersonIdent): PersonOversiktStatus? {
+        return database.connection.use { connection ->
+            connection.getPersonOversiktStatus(personident)
+        }
+    }
+
+    private fun Connection.getPersonOversiktStatus(personident: PersonIdent): PersonOversiktStatus? {
+        val personoversiktStatus = prepareStatement(GET_PERSON_OVERSIKT_STATUS).use {
+            it.setString(1, personident.value)
+            it.executeQuery().toList { toPPersonOversiktStatus() }
+        }
+        return personoversiktStatus.firstOrNull()?.toPersonOversiktStatus()
+    }
+
+    override fun createPersonOversiktStatusIfMissing(personident: PersonIdent): Boolean {
         database.connection.use { connection ->
-            val personoversiktStatus = connection.prepareStatement(GET_PERSON_OVERSIKT_STATUS).use {
-                it.setString(1, personident.value)
-                it.executeQuery().toList { toPPersonOversiktStatus() }
+            val missing = (connection.getPersonOversiktStatus(personident) == null)
+            if (missing) {
+                connection.createPersonOversiktStatus(true, PersonOversiktStatus(fnr = personident.value))
             }
-            return personoversiktStatus.firstOrNull()?.toPersonOversiktStatus()
+            return missing
+        }
+    }
+
+    override fun lagreVeilederForBruker(
+        veilederBrukerKnytning: VeilederBrukerKnytning,
+        tildeltAv: String,
+    ) {
+        database.connection.use { connection ->
+            val existingVeilederAndEnhet = connection.getExistingVeilederAndEnhet(veilederBrukerKnytning)
+            if (existingVeilederAndEnhet == null) {
+                throw SQLException("lagreVeilederForBruker failed, no existing personoversiktStatus found.")
+            } else if (existingVeilederAndEnhet.second != veilederBrukerKnytning.veilederIdent) {
+                connection.updateVeileder(veilederBrukerKnytning, existingVeilederAndEnhet)
+                connection.addVeilederHistorikk(existingVeilederAndEnhet, veilederBrukerKnytning, tildeltAv)
+                connection.commit()
+            }
+        }
+    }
+
+    private fun Connection.getExistingVeilederAndEnhet(veilederBrukerKnytning: VeilederBrukerKnytning) =
+        this.prepareStatement(GET_TILDELT_VEILEDER_QUERY).use {
+            it.setString(1, veilederBrukerKnytning.fnr)
+            it.executeQuery().toList {
+                Triple(
+                    getInt("id"),
+                    getString("tildelt_veileder"),
+                    getString("tildelt_enhet")
+                )
+            }
+        }.firstOrNull()
+
+    private fun Connection.updateVeileder(
+        veilederBrukerKnytning: VeilederBrukerKnytning,
+        existingVeilederAndEnhet: Triple<Int, String, String>
+    ) {
+        val rowCount = this.prepareStatement(UPDATE_TILDELT_VEILEDER_QUERY).use {
+            it.setString(1, veilederBrukerKnytning.veilederIdent)
+            it.setObject(2, Timestamp.from(Instant.now()))
+            it.setInt(3, existingVeilederAndEnhet.first)
+            it.executeUpdate()
+        }
+        if (rowCount != 1) {
+            throw SQLException("lagreVeilederForBruker failed, expected single row to be updated.")
+        }
+    }
+
+    private fun Connection.addVeilederHistorikk(
+        existingVeilederAndEnhet: Triple<Int, String, String>,
+        veilederBrukerKnytning: VeilederBrukerKnytning,
+        tildeltAv: String
+    ) {
+        this.prepareStatement(CREATE_VEILEDER_HISTORIKK).use {
+            it.setString(1, UUID.randomUUID().toString())
+            it.setInt(2, existingVeilederAndEnhet.first)
+            it.setDate(3, Date.valueOf(LocalDate.now()))
+            it.setString(4, veilederBrukerKnytning.veilederIdent)
+            it.setString(5, existingVeilederAndEnhet.third)
+            it.setString(6, tildeltAv)
+            it.execute()
         }
     }
 
@@ -210,6 +284,26 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             DO UPDATE SET
                 is_aktiv_manglende_medvirkning_vurdering = EXCLUDED.is_aktiv_manglende_medvirkning_vurdering,
                 sist_endret = EXCLUDED.sist_endret
+            """
+
+        private const val GET_TILDELT_VEILEDER_QUERY =
+            """
+            SELECT id,tildelt_veileder,tildelt_enhet FROM PERSON_OVERSIKT_STATUS
+            WHERE fnr = ?
+            """
+
+        private const val UPDATE_TILDELT_VEILEDER_QUERY =
+            """
+            UPDATE PERSON_OVERSIKT_STATUS
+            SET tildelt_veileder = ?, sist_endret = ?
+            WHERE id = ?
+            """
+
+        const val CREATE_VEILEDER_HISTORIKK =
+            """
+            INSERT INTO VEILEDER_HISTORIKK (
+                id,uuid,person_oversikt_status_id,fra_dato,tildelt_veileder,tildelt_enhet,tildelt_av
+            ) VALUES(DEFAULT,?,?,?,?,?,?)
             """
     }
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -207,11 +207,12 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
     ) {
         this.prepareStatement(CREATE_VEILEDER_HISTORIKK).use {
             it.setString(1, UUID.randomUUID().toString())
-            it.setInt(2, existingVeilederAndEnhet.id)
-            it.setDate(3, Date.valueOf(LocalDate.now()))
-            it.setString(4, veilederBrukerKnytning.veilederIdent)
-            it.setString(5, existingVeilederAndEnhet.enhet)
-            it.setString(6, tildeltAv)
+            it.setObject(2, OffsetDateTime.now())
+            it.setInt(3, existingVeilederAndEnhet.id)
+            it.setDate(4, Date.valueOf(LocalDate.now()))
+            it.setString(5, veilederBrukerKnytning.veilederIdent)
+            it.setString(6, existingVeilederAndEnhet.enhet)
+            it.setString(7, tildeltAv)
             it.execute()
         }
     }
@@ -304,16 +305,16 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         const val CREATE_VEILEDER_HISTORIKK =
             """
             INSERT INTO VEILEDER_HISTORIKK (
-                id,uuid,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av
-            ) VALUES(DEFAULT,?,?,?,?,?,?)
+                id,uuid,created_at,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av
+            ) VALUES(DEFAULT,?,?,?,?,?,?,?)
             """
     }
 }
 
 private data class VeilederAndEnhet(
     val id: Int,
-    val veileder: String,
-    val enhet: String,
+    val veileder: String?,
+    val enhet: String?,
 )
 
 private fun ResultSet.toPPersonOversiktStatus(): PPersonOversiktStatus =

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -6,7 +6,7 @@ CREATE TABLE VEILEDER_HISTORIKK (
   tildelt_dato              DATE,
   tildelt_veileder          VARCHAR(7)         NOT NULL,
   tildelt_enhet             VARCHAR(4)         NOT NULL,
-  tildelt_av                VARCHAR(7)         NOT NULL,
+  tildelt_av                VARCHAR(7)         NOT NULL
 );
 
 CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_oversikt_status_id);

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -1,5 +1,6 @@
 CREATE TABLE VEILEDER_HISTORIKK (
   id                        SERIAL             PRIMARY KEY,
+  created_at                TIMESTAMPTZ        NOT NULL,
   uuid                      CHAR(36)           NOT NULL UNIQUE,
   person_oversikt_status_id INTEGER REFERENCES PERSON_OVERSIKT_STATUS (id) ON DELETE CASCADE,
   tildelt_dato              DATE,

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -1,0 +1,16 @@
+CREATE TABLE VEILEDER_HISTORIKK (
+  id                        SERIAL             PRIMARY KEY,
+  uuid                      CHAR(36)           NOT NULL UNIQUE,
+  person_oversikt_status_id INTEGER REFERENCES PERSON_OVERSIKT_STATUS (id) ON DELETE CASCADE,
+  fra_dato                  DATE               NOT NULL,
+  tildelt_veileder          VARCHAR(7)         NOT NULL,
+  tildelt_enhet             VARCHAR(4)         NOT NULL,
+  tildelt_av                VARCHAR(7)
+);
+
+CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_oversikt_status_id);
+
+INSERT INTO VEILEDER_HISTORIKK (uuid,person_oversikt_status_id,fra_dato,tildelt_veileder,tildelt_enhet)
+SELECT gen_random_uuid(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
+FROM PERSON_OVERSIKT_STATUS
+WHERE tildelt_veileder IS NOT NULL;

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -2,7 +2,7 @@ CREATE TABLE VEILEDER_HISTORIKK (
   id                        SERIAL             PRIMARY KEY,
   uuid                      CHAR(36)           NOT NULL UNIQUE,
   person_oversikt_status_id INTEGER REFERENCES PERSON_OVERSIKT_STATUS (id) ON DELETE CASCADE,
-  tildelt_dato              DATE               NOT NULL,
+  tildelt_dato              DATE,
   tildelt_veileder          VARCHAR(7)         NOT NULL,
   tildelt_enhet             VARCHAR(4)         NOT NULL,
   tildelt_av                VARCHAR(7)

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -13,4 +13,4 @@ CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_overs
 INSERT INTO VEILEDER_HISTORIKK (uuid,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet)
 SELECT gen_random_uuid(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
 FROM PERSON_OVERSIKT_STATUS
-WHERE tildelt_veileder IS NOT NULL;
+WHERE tildelt_veileder IS NOT NULL AND tildelt_enhet IS NOT NULL;

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -12,6 +12,6 @@ CREATE TABLE VEILEDER_HISTORIKK (
 CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_oversikt_status_id);
 
 INSERT INTO VEILEDER_HISTORIKK (uuid,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet)
-SELECT gen_random_uuid(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
+SELECT gen_random_uuid(),now(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
 FROM PERSON_OVERSIKT_STATUS
 WHERE tildelt_veileder IS NOT NULL AND tildelt_enhet IS NOT NULL;

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -3,7 +3,7 @@ CREATE TABLE VEILEDER_HISTORIKK (
   created_at                TIMESTAMPTZ        NOT NULL,
   uuid                      CHAR(36)           NOT NULL UNIQUE,
   person_oversikt_status_id INTEGER REFERENCES PERSON_OVERSIKT_STATUS (id) ON DELETE CASCADE,
-  tildelt_dato              DATE,
+  tildelt_dato              DATE               NOT NULL,
   tildelt_veileder          VARCHAR(7)         NOT NULL,
   tildelt_enhet             VARCHAR(4)         NOT NULL,
   tildelt_av                VARCHAR(7)         NOT NULL
@@ -14,4 +14,4 @@ CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_overs
 INSERT INTO VEILEDER_HISTORIKK (uuid,created_at,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av)
 SELECT gen_random_uuid(),now(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet,'X000000'
 FROM PERSON_OVERSIKT_STATUS
-WHERE tildelt_veileder IS NOT NULL AND tildelt_enhet IS NOT NULL;
+WHERE tildelt_veileder IS NOT NULL AND tildelt_enhet IS NOT NULL AND oppfolgingstilfelle_start IS NOT NULL;

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -11,7 +11,7 @@ CREATE TABLE VEILEDER_HISTORIKK (
 
 CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_oversikt_status_id);
 
-INSERT INTO VEILEDER_HISTORIKK (uuid,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet)
+INSERT INTO VEILEDER_HISTORIKK (uuid,created_at,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet)
 SELECT gen_random_uuid(),now(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
 FROM PERSON_OVERSIKT_STATUS
 WHERE tildelt_veileder IS NOT NULL AND tildelt_enhet IS NOT NULL;

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -2,7 +2,7 @@ CREATE TABLE VEILEDER_HISTORIKK (
   id                        SERIAL             PRIMARY KEY,
   uuid                      CHAR(36)           NOT NULL UNIQUE,
   person_oversikt_status_id INTEGER REFERENCES PERSON_OVERSIKT_STATUS (id) ON DELETE CASCADE,
-  fra_dato                  DATE               NOT NULL,
+  tildelt_dato              DATE               NOT NULL,
   tildelt_veileder          VARCHAR(7)         NOT NULL,
   tildelt_enhet             VARCHAR(4)         NOT NULL,
   tildelt_av                VARCHAR(7)
@@ -10,7 +10,7 @@ CREATE TABLE VEILEDER_HISTORIKK (
 
 CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_oversikt_status_id);
 
-INSERT INTO VEILEDER_HISTORIKK (uuid,person_oversikt_status_id,fra_dato,tildelt_veileder,tildelt_enhet)
+INSERT INTO VEILEDER_HISTORIKK (uuid,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet)
 SELECT gen_random_uuid(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
 FROM PERSON_OVERSIKT_STATUS
 WHERE tildelt_veileder IS NOT NULL;

--- a/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
+++ b/src/main/resources/db/migration/V18_01__add_veileder_historikk.sql
@@ -6,12 +6,12 @@ CREATE TABLE VEILEDER_HISTORIKK (
   tildelt_dato              DATE,
   tildelt_veileder          VARCHAR(7)         NOT NULL,
   tildelt_enhet             VARCHAR(4)         NOT NULL,
-  tildelt_av                VARCHAR(7)
+  tildelt_av                VARCHAR(7)         NOT NULL,
 );
 
 CREATE INDEX IX_VEILEDER_HISTORIKK_STATUS_ID ON VEILEDER_HISTORIKK (person_oversikt_status_id);
 
-INSERT INTO VEILEDER_HISTORIKK (uuid,created_at,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet)
-SELECT gen_random_uuid(),now(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet
+INSERT INTO VEILEDER_HISTORIKK (uuid,created_at,person_oversikt_status_id,tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av)
+SELECT gen_random_uuid(),now(),id,oppfolgingstilfelle_start,tildelt_veileder,tildelt_enhet,'X000000'
 FROM PERSON_OVERSIKT_STATUS
 WHERE tildelt_veileder IS NOT NULL AND tildelt_enhet IS NOT NULL;

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -18,8 +18,8 @@ import no.nav.syfo.personstatus.api.v2.model.PersonOversiktStatusDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningVurderingType
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
 import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
-import no.nav.syfo.personstatus.db.lagreVeilederForBruker
 import no.nav.syfo.personstatus.domain.*
+import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_NO_NAME_FNR
@@ -60,6 +60,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
 
             val personoversiktStatusService = internalMockEnvironment.personoversiktStatusService
             val kafkaOppfolgingstilfellePersonService = TestKafkaModule.kafkaOppfolgingstilfellePersonService
+            val personOversiktStatusRepository = PersonOversiktStatusRepository(database)
 
             val personIdentDefault = PersonIdent(ARBEIDSTAKER_FNR)
 
@@ -185,7 +186,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     )
 
                     val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
-                    database.lagreVeilederForBruker(tilknytning)
+                    personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
 
                     with(
                         handleRequest(HttpMethod.Get, url) {
@@ -218,7 +219,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     )
 
                     val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
-                    database.lagreVeilederForBruker(tilknytning)
+                    personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
 
                     with(
                         handleRequest(HttpMethod.Get, url) {
@@ -382,7 +383,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     )
 
                     val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
-                    database.lagreVeilederForBruker(tilknytning)
+                    personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
 
                     with(
                         handleRequest(HttpMethod.Get, url) {
@@ -437,7 +438,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     )
 
                     val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
-                    database.lagreVeilederForBruker(tilknytning)
+                    personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
 
                     with(
                         handleRequest(HttpMethod.Get, url) {
@@ -672,11 +673,11 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     )
 
                     val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, personIdent.value)
-                    database.lagreVeilederForBruker(tilknytning)
                     database.setTildeltEnhet(
                         ident = personIdent,
                         enhet = NAV_ENHET,
                     )
+                    personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
                     with(
                         handleRequest(HttpMethod.Get, url) {
                             addHeader(HttpHeaders.Authorization, bearerHeader(validToken))

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersontildelingApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersontildelingApiV2Spek.kt
@@ -153,7 +153,7 @@ object PersontildelingApiV2Spek : Spek({
                             historikkDTO.tildeltVeileder shouldBeEqualTo veilederBrukerKnytning.veilederIdent
                             historikkDTO.tildeltEnhet shouldBeEqualTo NAV_ENHET
                             historikkDTO.tildeltAv shouldBeEqualTo VEILEDER_ID
-                            historikkDTO.fraDato shouldBeEqualTo LocalDate.now()
+                            historikkDTO.tildeltDato shouldBeEqualTo LocalDate.now()
                         }
                     }
                     it("returns OK when request for person som ikke finnes i oversikten is successful") {
@@ -176,7 +176,7 @@ object PersontildelingApiV2Spek : Spek({
                             historikkDTO.tildeltVeileder shouldBeEqualTo veilederBrukerKnytning.veilederIdent
                             historikkDTO.tildeltEnhet shouldBeEqualTo NAV_ENHET
                             historikkDTO.tildeltAv shouldBeEqualTo VEILEDER_ID
-                            historikkDTO.fraDato shouldBeEqualTo LocalDate.now()
+                            historikkDTO.tildeltDato shouldBeEqualTo LocalDate.now()
                         }
                     }
                     it("returns OK when request for person som finnes i oversikten uten enhet is successful") {
@@ -203,7 +203,7 @@ object PersontildelingApiV2Spek : Spek({
                             historikkDTO.tildeltVeileder shouldBeEqualTo veilederBrukerKnytning.veilederIdent
                             historikkDTO.tildeltEnhet shouldBeEqualTo NAV_ENHET
                             historikkDTO.tildeltAv shouldBeEqualTo VEILEDER_ID
-                            historikkDTO.fraDato shouldBeEqualTo LocalDate.now()
+                            historikkDTO.tildeltDato shouldBeEqualTo LocalDate.now()
                         }
                     }
                     it("returns OK when already assigned to veileder") {

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersontildelingApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersontildelingApiV2Spek.kt
@@ -5,22 +5,28 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.ktor.util.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.api.v2.endpoints.personTildelingApiV2Path
 import no.nav.syfo.personstatus.api.v2.model.VeilederBrukerKnytningDTO
 import no.nav.syfo.personstatus.domain.VeilederBrukerKnytning
 import no.nav.syfo.personstatus.db.*
+import no.nav.syfo.personstatus.domain.PersonIdent
+import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_2_FNR
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_NO_ACCESS
 import no.nav.syfo.testutil.UserConstants.NAV_ENHET
 import no.nav.syfo.testutil.UserConstants.VEILEDER_ID
+import no.nav.syfo.testutil.UserConstants.VEILEDER_ID_2
+import no.nav.syfo.testutil.database.setTildeltEnhet
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
 import no.nav.syfo.util.configuredJacksonMapper
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
 
 @InternalAPI
 object PersontildelingApiV2Spek : Spek({
@@ -32,6 +38,10 @@ object PersontildelingApiV2Spek : Spek({
 
             val externalMockEnvironment = ExternalMockEnvironment.instance
             val database = externalMockEnvironment.database
+            val internalMockEnvironment = InternalMockEnvironment.instance
+            val personoversiktStatusService = internalMockEnvironment.personoversiktStatusService
+            val personOversiktStatusRepository = PersonOversiktStatusRepository(database)
+            val personTildelingService = internalMockEnvironment.personTildelingService
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment
@@ -53,7 +63,14 @@ object PersontildelingApiV2Spek : Spek({
                 val url = "$baseUrl/registrer"
 
                 it("skal lagre liste med veiledertilknytninger") {
-
+                    personoversiktStatusService.upsertAktivitetskravvurderingStatus(
+                        personident = PersonIdent(ARBEIDSTAKER_FNR),
+                        isAktivVurdering = true,
+                    )
+                    database.setTildeltEnhet(
+                        ident = PersonIdent(ARBEIDSTAKER_FNR),
+                        enhet = NAV_ENHET,
+                    )
                     with(
                         handleRequest(HttpMethod.Post, url) {
                             addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -69,8 +86,16 @@ object PersontildelingApiV2Spek : Spek({
             describe("/personer") {
                 describe("GET veilederknytning for person") {
                     it("returns person with correct values") {
+                        personoversiktStatusService.upsertAktivitetskravvurderingStatus(
+                            personident = PersonIdent(ARBEIDSTAKER_FNR),
+                            isAktivVurdering = true,
+                        )
+                        database.setTildeltEnhet(
+                            ident = PersonIdent(ARBEIDSTAKER_FNR),
+                            enhet = NAV_ENHET,
+                        )
                         val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
-                        database.lagreVeilederForBruker(tilknytning)
+                        personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
 
                         val url = "$personTildelingApiV2Path/personer/single"
                         with(
@@ -86,9 +111,6 @@ object PersontildelingApiV2Spek : Spek({
                         }
                     }
                     it("returns 404 when person does not exist") {
-                        val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
-                        database.lagreVeilederForBruker(tilknytning)
-
                         val url = "$personTildelingApiV2Path/personer/single"
                         with(
                             handleRequest(HttpMethod.Get, url) {
@@ -102,10 +124,17 @@ object PersontildelingApiV2Spek : Spek({
                 }
                 describe("POST veilederknytning for person") {
                     val url = "$personTildelingApiV2Path/personer/single"
-
-                    val veilederBrukerKnytning = VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)
+                    val veilederBrukerKnytning = VeilederBrukerKnytning(VEILEDER_ID_2, ARBEIDSTAKER_FNR)
 
                     it("returns OK when request is successful") {
+                        personoversiktStatusService.upsertAktivitetskravvurderingStatus(
+                            personident = PersonIdent(ARBEIDSTAKER_FNR),
+                            isAktivVurdering = true,
+                        )
+                        database.setTildeltEnhet(
+                            ident = PersonIdent(ARBEIDSTAKER_FNR),
+                            enhet = NAV_ENHET,
+                        )
                         with(
                             handleRequest(HttpMethod.Post, url) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -117,10 +146,93 @@ object PersontildelingApiV2Spek : Spek({
 
                             val person = database.getPersonOversiktStatusList(fnr = veilederBrukerKnytning.fnr).first()
                             person.veilederIdent shouldBeEqualTo veilederBrukerKnytning.veilederIdent
+
+                            val historikk = database.getVeilederHistorikk(ARBEIDSTAKER_FNR)
+                            historikk.size shouldBeEqualTo 1
+                            val historikkDTO = historikk.first()
+                            historikkDTO.tildeltVeileder shouldBeEqualTo veilederBrukerKnytning.veilederIdent
+                            historikkDTO.tildeltEnhet shouldBeEqualTo NAV_ENHET
+                            historikkDTO.tildeltAv shouldBeEqualTo VEILEDER_ID
+                            historikkDTO.fraDato shouldBeEqualTo LocalDate.now()
+                        }
+                    }
+                    it("returns OK when request for person som ikke finnes i oversikten is successful") {
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                setBody(objectMapper.writeValueAsString(veilederBrukerKnytning))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                            val person =
+                                database.getPersonOversiktStatusList(fnr = veilederBrukerKnytning.fnr).first()
+                            person.veilederIdent shouldBeEqualTo veilederBrukerKnytning.veilederIdent
+
+                            val historikk = database.getVeilederHistorikk(ARBEIDSTAKER_FNR)
+                            historikk.size shouldBeEqualTo 1
+                            val historikkDTO = historikk.first()
+                            historikkDTO.tildeltVeileder shouldBeEqualTo veilederBrukerKnytning.veilederIdent
+                            historikkDTO.tildeltEnhet shouldBeEqualTo NAV_ENHET
+                            historikkDTO.tildeltAv shouldBeEqualTo VEILEDER_ID
+                            historikkDTO.fraDato shouldBeEqualTo LocalDate.now()
+                        }
+                    }
+                    it("returns OK when already assigned to veileder") {
+                        runBlocking {
+                            personTildelingService.lagreKnytningMellomVeilederOgBruker(
+                                listOf(VeilederBrukerKnytning(VEILEDER_ID_2, ARBEIDSTAKER_FNR)),
+                                VEILEDER_ID
+                            )
+                        }
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                setBody(objectMapper.writeValueAsString(veilederBrukerKnytning))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                            val person = database.getPersonOversiktStatusList(fnr = veilederBrukerKnytning.fnr).first()
+                            person.veilederIdent shouldBeEqualTo veilederBrukerKnytning.veilederIdent
+                            val historikk = database.getVeilederHistorikk(ARBEIDSTAKER_FNR)
+                            historikk.size shouldBeEqualTo 1
+                        }
+                    }
+                    it("returns OK when already assigned to veileder and then assigned to a different") {
+                        runBlocking {
+                            personTildelingService.lagreKnytningMellomVeilederOgBruker(
+                                listOf(VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_FNR)),
+                                VEILEDER_ID
+                            )
+                        }
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                setBody(objectMapper.writeValueAsString(veilederBrukerKnytning))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                            val person = database.getPersonOversiktStatusList(fnr = veilederBrukerKnytning.fnr).first()
+                            person.veilederIdent shouldBeEqualTo veilederBrukerKnytning.veilederIdent
+                            val historikk = database.getVeilederHistorikk(ARBEIDSTAKER_FNR)
+                            historikk.size shouldBeEqualTo 2
                         }
                     }
 
                     it("returns Unauthorized when missing token") {
+                        personoversiktStatusService.upsertAktivitetskravvurderingStatus(
+                            personident = PersonIdent(ARBEIDSTAKER_FNR),
+                            isAktivVurdering = true,
+                        )
+                        database.setTildeltEnhet(
+                            ident = PersonIdent(ARBEIDSTAKER_FNR),
+                            enhet = NAV_ENHET,
+                        )
                         with(
                             handleRequest(HttpMethod.Post, url) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -132,11 +244,20 @@ object PersontildelingApiV2Spek : Spek({
                     }
 
                     it("returns Forbidden when no access to person") {
+                        personoversiktStatusService.upsertAktivitetskravvurderingStatus(
+                            personident = PersonIdent(ARBEIDSTAKER_FNR),
+                            isAktivVurdering = true,
+                        )
+                        setTildeltEnhet(database)
                         with(
                             handleRequest(HttpMethod.Post, url) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                                 addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                setBody(objectMapper.writeValueAsString(VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_NO_ACCESS)))
+                                setBody(
+                                    objectMapper.writeValueAsString(
+                                        VeilederBrukerKnytning(VEILEDER_ID, ARBEIDSTAKER_NO_ACCESS)
+                                    )
+                                )
                             }
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.Forbidden

--- a/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/InternalMockEnvironment.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.testutil
 
 import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.personstatus.PersonTildelingService
 import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.personstatus.infrastructure.clients.ereg.EregClient
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
@@ -92,6 +93,10 @@ class InternalMockEnvironment private constructor() {
         database = database,
         pdlClient = pdlClient,
         personoversiktStatusRepository = personoversiktRepository,
+    )
+    val personTildelingService = PersonTildelingService(
+        personoversiktStatusRepository = personoversiktRepository,
+        personBehandlendeEnhetService = personBehandlendeEnhetService,
     )
 
     companion object {

--- a/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
@@ -11,8 +11,10 @@ import no.nav.syfo.personstatus.infrastructure.clients.arbeidsuforhet.Arbeidsufo
 import no.nav.syfo.personstatus.infrastructure.clients.manglendemedvirkning.ManglendeMedvirkningClient
 import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.OppfolgingsoppgaveClient
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
+import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.personstatus.infrastructure.clients.meroppfolging.MerOppfolgingClient
 import no.nav.syfo.personstatus.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.personstatus.infrastructure.cronjob.behandlendeenhet.PersonBehandlendeEnhetService
 import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository
 
 fun Application.testApiModule(
@@ -60,11 +62,20 @@ fun Application.testApiModule(
         istilgangskontrollEnv = externalMockEnvironment.environment.clients.istilgangskontroll,
         httpClient = externalMockEnvironment.mockHttpClient
     )
+    val behandlendeEnhetClient = BehandlendeEnhetClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = externalMockEnvironment.environment.clients.syfobehandlendeenhet,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
     val personoversiktRepository = PersonOversiktStatusRepository(database = externalMockEnvironment.database)
     val personoversiktStatusService = PersonoversiktStatusService(
         database = externalMockEnvironment.database,
         pdlClient = pdlClient,
         personoversiktStatusRepository = personoversiktRepository,
+    )
+    val personBehandlendeEnhetService = PersonBehandlendeEnhetService(
+        database = externalMockEnvironment.database,
+        behandlendeEnhetClient = behandlendeEnhetClient,
     )
 
     this.apiModule(
@@ -81,5 +92,7 @@ fun Application.testApiModule(
             aktivitetskravClient = aktivitetskravClient,
             merOppfolgingClient = merOppfolgingClient,
         ),
+        personBehandlendeEnhetService = personBehandlendeEnhetService,
+        personoversiktStatusRepository = personoversiktRepository,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testutil/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestDatabase.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import no.nav.syfo.personstatus.infrastructure.database.DatabaseInterface
+import no.nav.syfo.personstatus.infrastructure.database.toList
 import org.flywaydb.core.Flyway
 import java.sql.Connection
 import java.sql.Timestamp
@@ -100,7 +101,7 @@ const val querySetTildeltEnhet =
 
 fun DatabaseInterface.setTildeltEnhet(
     ident: PersonIdent,
-    enhet: String,
+    enhet: String?,
 ) {
     this.connection.use { connection ->
         connection.prepareStatement(querySetTildeltEnhet).use {
@@ -150,3 +151,32 @@ fun DatabaseInterface.setSistEndret(fnr: String, sistEndret: Timestamp) {
         connection.commit()
     }
 }
+
+const val queryGetVeilederHistorikk =
+    """
+        SELECT fra_dato,tildelt_veileder,tildelt_enhet,tildelt_av 
+        FROM VEILEDER_HISTORIKK
+        WHERE person_oversikt_status_id IN (select id from person_oversikt_status where fnr=?)
+    """
+
+fun DatabaseInterface.getVeilederHistorikk(fnr: String) =
+    this.connection.use {
+        connection.prepareStatement(queryGetVeilederHistorikk).use {
+            it.setString(1, fnr)
+            it.executeQuery().toList {
+                VeilederHistorikkDTO(
+                    fraDato = getDate(1).toLocalDate(),
+                    tildeltVeileder = getString(2),
+                    tildeltEnhet = getString(3),
+                    tildeltAv = getString(4),
+                )
+            }
+        }
+    }
+
+data class VeilederHistorikkDTO(
+    val fraDato: LocalDate,
+    val tildeltVeileder: String,
+    val tildeltEnhet: String,
+    val tildeltAv: String,
+)

--- a/src/test/kotlin/no/nav/syfo/testutil/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestDatabase.kt
@@ -165,7 +165,7 @@ fun DatabaseInterface.getVeilederHistorikk(fnr: String) =
             it.setString(1, fnr)
             it.executeQuery().toList {
                 VeilederHistorikkDTO(
-                    fraDato = getDate(1).toLocalDate(),
+                    tildeltDato = getDate(1).toLocalDate(),
                     tildeltVeileder = getString(2),
                     tildeltEnhet = getString(3),
                     tildeltAv = getString(4),
@@ -175,7 +175,7 @@ fun DatabaseInterface.getVeilederHistorikk(fnr: String) =
     }
 
 data class VeilederHistorikkDTO(
-    val fraDato: LocalDate,
+    val tildeltDato: LocalDate,
     val tildeltVeileder: String,
     val tildeltEnhet: String,
     val tildeltAv: String,

--- a/src/test/kotlin/no/nav/syfo/testutil/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestDatabase.kt
@@ -154,7 +154,7 @@ fun DatabaseInterface.setSistEndret(fnr: String, sistEndret: Timestamp) {
 
 const val queryGetVeilederHistorikk =
     """
-        SELECT fra_dato,tildelt_veileder,tildelt_enhet,tildelt_av 
+        SELECT tildelt_dato,tildelt_veileder,tildelt_enhet,tildelt_av 
         FROM VEILEDER_HISTORIKK
         WHERE person_oversikt_status_id IN (select id from person_oversikt_status where fnr=?)
     """

--- a/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
@@ -19,6 +19,7 @@ object UserConstants {
     const val NAV_ENHET = "0330"
     const val NAV_ENHET_2 = "0331"
     const val VEILEDER_ID = "Z999999"
+    const val VEILEDER_ID_2 = "Z999998"
     const val VEILEDER_IDENT_NO_AZURE_AD_TOKEN = "Z00000_no_azure_ad_token"
     const val VIRKSOMHETSNUMMER = "123456789"
     const val VIRKSOMHETSNUMMER_2 = "123456781"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Nå tror jeg dette begynner å bli bra: database-scriptet initialiserer med eksisterende veilederknytninger, og når det gjøres nye tildelinger skal de bli lagret i den nye historikk-databasetabellen. Måtte refaktorere for å være sikker på at vi alltid har en eksisterende forekomst med enhetstilknytning først (siden det også blir med i historikken), dvs før tildelingen til veileder gjøres. Siden dette nå kan gjøres fra syfomodiaperson har vi utgangspunktet ingen garanti for at det finnes en rad i personoversikt-tabellen før tildelingen gjøres.

API kommer i en egen PR tenkte jeg.
