### PR TITLE
IS-2805: Tilpasset cronjob som oppdaterer tildelt enhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -26,7 +26,7 @@ interface IPersonOversiktStatusRepository {
 
     fun getVeilederTilknytningHistorikk(personident: PersonIdent): List<VeilederTildelingHistorikkDTO>
 
-    fun getPersonerWithOppgaveAndOldEnhet(): List<Pair<PersonIdent, String?>>
+    fun getPersonerToUpdateEnhet(): List<Pair<PersonIdent, String?>>
 
     fun updatePersonTildeltEnhetAndRemoveTildeltVeileder(personIdent: PersonIdent, enhetId: String)
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -26,7 +26,7 @@ interface IPersonOversiktStatusRepository {
 
     fun getVeilederTilknytningHistorikk(personident: PersonIdent): List<VeilederTildelingHistorikkDTO>
 
-    fun getPersonerToUpdateEnhet(): List<Pair<PersonIdent, String?>>
+    fun getAktivePersonerWithOutdatedEnhet(): List<Pair<PersonIdent, String?>>
 
     fun updatePersonTildeltEnhetAndRemoveTildeltVeileder(personIdent: PersonIdent, enhetId: String)
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjob.kt
@@ -20,7 +20,7 @@ class PersonBehandlendeEnhetCronjob(
         log.info("Run PersonBehandlendeEnhetCronjob")
         val result = CronjobResult()
 
-        personBehandlendeEnhetService.getPersonerToCheckForUpdatedEnhet()
+        personBehandlendeEnhetService.getAktivePersonerWithOutdatedEnhet()
             .forEach { personIdentTildeltEnhetPair ->
                 try {
                     val (personIdent, tildeltEnhet) = personIdentTildeltEnhetPair

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetService.kt
@@ -9,8 +9,8 @@ class PersonBehandlendeEnhetService(
     private val personoversiktStatusRepository: PersonOversiktStatusRepository,
     private val behandlendeEnhetClient: BehandlendeEnhetClient,
 ) {
-    fun getPersonerToCheckForUpdatedEnhet(): List<Pair<PersonIdent, String?>> =
-        personoversiktStatusRepository.getPersonerToUpdateEnhet()
+    fun getAktivePersonerWithOutdatedEnhet(): List<Pair<PersonIdent, String?>> =
+        personoversiktStatusRepository.getAktivePersonerWithOutdatedEnhet()
 
     suspend fun updateBehandlendeEnhet(
         personIdent: PersonIdent,

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetService.kt
@@ -10,7 +10,7 @@ class PersonBehandlendeEnhetService(
     private val behandlendeEnhetClient: BehandlendeEnhetClient,
 ) {
     fun getPersonerToCheckForUpdatedEnhet(): List<Pair<PersonIdent, String?>> =
-        personoversiktStatusRepository.getPersonerWithOppgaveAndOldEnhet()
+        personoversiktStatusRepository.getPersonerToUpdateEnhet()
 
     suspend fun updateBehandlendeEnhet(
         personIdent: PersonIdent,

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -227,7 +227,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             }
         }
 
-    override fun getPersonerToUpdateEnhet(): List<Pair<PersonIdent, String?>> =
+    override fun getAktivePersonerWithOutdatedEnhet(): List<Pair<PersonIdent, String?>> =
         database.connection.use { connection ->
             connection.prepareStatement(GET_PERSONER_TO_UPDATE_ENHET).use {
                 it.executeQuery().toList {

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -227,9 +227,9 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             }
         }
 
-    override fun getPersonerWithOppgaveAndOldEnhet(): List<Pair<PersonIdent, String?>> =
+    override fun getPersonerToUpdateEnhet(): List<Pair<PersonIdent, String?>> =
         database.connection.use { connection ->
-            connection.prepareStatement(GET_PERSONER_WITH_OPPGAVE_AND_OLD_ENHET).use {
+            connection.prepareStatement(GET_PERSONER_TO_UPDATE_ENHET).use {
                 it.executeQuery().toList {
                     Pair(
                         PersonIdent(getString("fnr")),
@@ -387,11 +387,11 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         )
         """
 
-        private const val GET_PERSONER_WITH_OPPGAVE_AND_OLD_ENHET =
+        private const val GET_PERSONER_TO_UPDATE_ENHET =
             """
             SELECT fnr, tildelt_enhet
             FROM PERSON_OVERSIKT_STATUS
-            WHERE $AKTIV_OPPGAVE_WHERE_CLAUSE    
+            WHERE (oppfolgingstilfelle_end + INTERVAL '16 DAY' >= now() OR $AKTIV_OPPGAVE_WHERE_CLAUSE)
             AND (tildelt_enhet_updated_at IS NULL OR tildelt_enhet_updated_at <= NOW() - INTERVAL '24 HOURS')
             ORDER BY tildelt_enhet_updated_at ASC
             LIMIT 2000


### PR DESCRIPTION
For at en person skal være søkbar må vedkommende være tilknyttet en enhet (Nav-kontor). 
I dag holder vi bare `tildelt_enhet` oppdatert for personer som er aktive i oversikten (har aktiv oppgave). 
For å kunne søke opp sykmeldte personer som ikke har aktiv oppgave i oversikten må vi også holde tildelt enhet oppdatert for personer som har aktivt oppfølgingstilfelle (ikke mer enn 16 dager siden slutt-dato på tilfellet).
