### PR TITLE
IS-2794: Add active oppfolgingstilfelle clause to search query

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -269,7 +269,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
 
     override fun searchPerson(searchQuery: SearchQuery): List<PersonOversiktStatus> {
         val initials = searchQuery.initials.value.toList()
-        val baseQuery = "SELECT * FROM PERSON_OVERSIKT_STATUS p WHERE "
+        val baseQuery = "SELECT * FROM PERSON_OVERSIKT_STATUS p WHERE oppfolgingstilfelle_end + INTERVAL '16 DAY' >= now() AND "
         val whereStatement =
             "p.name ILIKE ? AND " + initials.drop(1).joinToString(" AND ") { "p.name ILIKE ?" }
         return database.connection.use { connection ->

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktSearchApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktSearchApiSpek.kt
@@ -11,15 +11,23 @@ import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.UserConstants.VEILEDER_ID
+import no.nav.syfo.testutil.generator.generateOppfolgingstilfelle
 import no.nav.syfo.util.bearerHeader
 import no.nav.syfo.util.configuredJacksonMapper
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
 
 object PersonoversiktSearchApiSpek : Spek({
 
     val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    val activeOppfolgingstilfelle = generateOppfolgingstilfelle(
+        start = LocalDate.now().minusWeeks(15),
+        end = LocalDate.now().plusWeeks(1),
+        antallSykedager = null,
+    )
 
     describe("PersonoversiktSearchApi") {
         with(TestApplicationEngine()) {
@@ -45,9 +53,9 @@ object PersonoversiktSearchApiSpek : Spek({
                 navIdent = VEILEDER_ID,
             )
 
-            it("returns person matching search when veileder has access to person") {
+            it("returns sykmeldt person matching search when veileder has access to person") {
                 val newPersonOversiktStatus =
-                    PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR, navn = "Fornavn Etternavn")
+                    PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR, navn = "Fornavn Etternavn", latestOppfolgingstilfelle = activeOppfolgingstilfelle)
                 personOversiktStatusRepository.createPersonOversiktStatus(newPersonOversiktStatus)
                 val searchQueryDTO = SearchQueryDTO(initials = "FE")
 
@@ -67,7 +75,7 @@ object PersonoversiktSearchApiSpek : Spek({
 
             it("returns nothing when no person matching search") {
                 val newPersonOversiktStatus =
-                    PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR, navn = "Fornavn Etternavn")
+                    PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR, navn = "Fornavn Etternavn", latestOppfolgingstilfelle = activeOppfolgingstilfelle)
                 personOversiktStatusRepository.createPersonOversiktStatus(newPersonOversiktStatus)
                 val searchQueryDTO = SearchQueryDTO(initials = "AB")
 
@@ -82,9 +90,9 @@ object PersonoversiktSearchApiSpek : Spek({
                 }
             }
 
-            it("returns nothing when person matching search but veileder has no access to person") {
+            it("returns nothing when sykmeldt person matching search but veileder has no access to person") {
                 val newPersonOversiktStatus =
-                    PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_NO_ACCESS, navn = "Fornavn Etternavn")
+                    PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_NO_ACCESS, navn = "Fornavn Etternavn", latestOppfolgingstilfelle = activeOppfolgingstilfelle)
                 personOversiktStatusRepository.createPersonOversiktStatus(newPersonOversiktStatus)
                 val searchQueryDTO = SearchQueryDTO(initials = "FE")
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Veileder skal kunne søke opp sykmeldte personer. Legger derfor til sjekk i sql-spørringen på at sluttdato på oppfølgingstilfellet ikke er mer enn 16 dager siden, da regner vi oppfølgingstilfellet som aktivt og personen som sykmeldt.
