### PR TITLE
IS-2784: Forslag til indekser for søk

### DIFF
--- a/src/main/resources/db/migration/V18_05__name_index.sql
+++ b/src/main/resources/db/migration/V18_05__name_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ix_person_oversikt_status_name
+    ON person_oversikt_status (name)
+    WHERE person_oversikt_status.name IS NOT NULL;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lager indekser til bruk i søk. Spørringen som brukes i søket er definert [her](https://github.com/navikt/syfooversiktsrv/blob/master/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt#L273)

Vi har allerede en indeks på fodselsdato definert som:
```
CREATE INDEX ix_person_oversikt_status_fodselsdato
    ON person_oversikt_status (fodselsdato)
    WHERE person_oversikt_status.fodselsdato IS NOT NULL;
```
Spørsmål: 

- Burde vi legge til en where clause på at både `fodselsdato`, `name` og `oppfolgingstilfelle_end` ikke er null i alle indeksene?
- Burde vi heller ha én indeks som kombinerer disse tre kolonnene?