### PR TITLE
IS-2794: Index oppfolgingstilfelle_end

### DIFF
--- a/src/main/resources/db/migration/V18_04__oppfolgingstilfelle_end_index.sql
+++ b/src/main/resources/db/migration/V18_04__oppfolgingstilfelle_end_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ix_person_oversikt_status_oppfolgingstilfelle_end
+    ON person_oversikt_status (oppfolgingstilfelle_end)
+    WHERE person_oversikt_status.oppfolgingstilfelle_end IS NOT NULL;


### PR DESCRIPTION
Lager indeks på denne kolonnen som brukes til å sjekke at person har aktivt oppfølgingstilfelle (er sykmeldt) i søket.
