### PR TITLE
IS-2829: Include persons with active oppgave in search query

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -295,7 +295,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
     override fun searchPerson(searchQuery: SearchQuery): List<PersonOversiktStatus> {
         val initials = searchQuery.initials.value.toList()
         val baseQuery =
-            "SELECT * FROM PERSON_OVERSIKT_STATUS p WHERE p.oppfolgingstilfelle_end + INTERVAL '16 DAY' >= now() AND p.fodselsdato = ? AND "
+            "SELECT * FROM PERSON_OVERSIKT_STATUS p WHERE (p.oppfolgingstilfelle_end + INTERVAL '16 DAY' >= now() OR $AKTIV_OPPGAVE_WHERE_CLAUSE) AND p.fodselsdato = ? AND "
         val nameQuery =
             "p.name ILIKE ? AND " + initials.drop(1).joinToString(" AND ") { "p.name ILIKE ?" }
         return database.connection.use { connection ->

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/database/PersonOversiktStatusRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/database/PersonOversiktStatusRepositorySpek.kt
@@ -260,6 +260,30 @@ class PersonOversiktStatusRepositorySpek : Spek({
                     }
                 }
 
+                it("finds person with oppgave but not sykmeldt when searching with correct initials and birthdate") {
+                    val newPersonOversiktStatus = PersonOversiktStatus(
+                        fnr = UserConstants.ARBEIDSTAKER_FNR,
+                        fodselsdato = fodselsdato,
+                        navn = "Fornavn Mellomnavn Etternavn",
+                        trengerOppfolging = true,
+                        latestOppfolgingstilfelle = inactiveOppfolgingstilfelle,
+                    )
+                    personOversiktStatusRepository.createPersonOversiktStatus(newPersonOversiktStatus)
+
+                    searchPerson(initials = "FME", birthdate = fodselsdato).let {
+                        it.size shouldBe 1
+                        it.first().navn shouldBeEqualTo "Fornavn Mellomnavn Etternavn"
+                    }
+                    searchPerson("FE", birthdate = fodselsdato).let {
+                        it.size shouldBe 1
+                        it.first().navn shouldBeEqualTo "Fornavn Mellomnavn Etternavn"
+                    }
+                    searchPerson("FM", birthdate = fodselsdato).let {
+                        it.size shouldBe 1
+                        it.first().navn shouldBeEqualTo "Fornavn Mellomnavn Etternavn"
+                    }
+                }
+
                 it("finds relevant sykmeldt person when searching with correct lowercase initials and birthdate") {
                     val newPersonOversiktStatus = PersonOversiktStatus(
                         fnr = UserConstants.ARBEIDSTAKER_FNR,
@@ -330,7 +354,7 @@ class PersonOversiktStatusRepositorySpek : Spek({
                     searchPerson("FME", birthdate = fodselsdato).size shouldBe 0
                 }
 
-                it("returns empty list when matching initials and birthdate but no active oppfolgingstilfelle") {
+                it("returns empty list when matching initials and birthdate but no active oppfolgingstilfelle or oppgave") {
                     val newPersonOversiktStatus = PersonOversiktStatus(
                         fnr = UserConstants.ARBEIDSTAKER_FNR,
                         fodselsdato = fodselsdato,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi avklarte at vi ønsker at søket også skal inkludere personer som har aktiv oppgave i oversikten, ikke bare personer med aktivt oppfølgingstilfelle.