### PR TITLE
IS-2825: Add navn og fodselsdato when new oppfolgingstilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -115,6 +115,7 @@ fun main() {
             )
             val personoversiktStatusRepository = PersonOversiktStatusRepository(database = database)
             oppfolgingstilfelleService = OppfolgingstilfelleService(
+                pdlClient = pdlClient,
                 personOversiktStatusRepository = personoversiktStatusRepository,
             )
             personoversiktStatusService = PersonoversiktStatusService(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/AktivitetskravVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/AktivitetskravVurderingConsumer.kt
@@ -14,7 +14,7 @@ class AktivitetskravVurderingConsumer(
 
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, AktivitetskravVurderingRecord>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, AktivitetskravVurderingRecord>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             processRecords(records)

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/KafkaDialogmotekandidatEndringService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/KafkaDialogmotekandidatEndringService.kt
@@ -16,7 +16,7 @@ class KafkaDialogmotekandidatEndringService(
 
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KafkaDialogmotekandidatEndring>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KafkaDialogmotekandidatEndring>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             processRecords(records)

--- a/src/main/kotlin/no/nav/syfo/dialogmotestatusendring/kafka/KafkaDialogmoteStatusendringService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotestatusendring/kafka/KafkaDialogmoteStatusendringService.kt
@@ -17,7 +17,7 @@ class KafkaDialogmoteStatusendringService(
 ) : KafkaConsumerService<KDialogmoteStatusEndring> {
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KDialogmoteStatusEndring>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KDialogmoteStatusEndring>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             processRecords(records)

--- a/src/main/kotlin/no/nav/syfo/frisktilarbeid/kafka/FriskTilArbeidVedtakConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/frisktilarbeid/kafka/FriskTilArbeidVedtakConsumer.kt
@@ -17,7 +17,7 @@ class FriskTilArbeidVedtakConsumer(
 
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, VedtakStatusRecord>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, VedtakStatusRecord>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             processRecords(records)

--- a/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
@@ -2,12 +2,12 @@ package no.nav.syfo.identhendelse
 
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.infrastructure.database.DatabaseInterface
-import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.identhendelse.database.queryDeletePersonOversiktStatusFnr
 import no.nav.syfo.identhendelse.database.updatePersonOversiktStatusFnr
 import no.nav.syfo.identhendelse.database.updatePersonOversiktStatusVeileder
 import no.nav.syfo.identhendelse.kafka.KafkaIdenthendelseDTO
+import no.nav.syfo.personstatus.application.IPdlClient
 import no.nav.syfo.personstatus.infrastructure.COUNT_KAFKA_CONSUMER_PDL_AKTOR_UPDATES
 import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
 import no.nav.syfo.personstatus.domain.PPersonOversiktStatus
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory
 
 class IdenthendelseService(
     private val database: DatabaseInterface,
-    private val pdlClient: PdlClient,
+    private val pdlClient: IPdlClient,
 ) {
 
     private val log: Logger = LoggerFactory.getLogger(IdenthendelseService::class.java)

--- a/src/main/kotlin/no/nav/syfo/identhendelse/kafka/IdenthendelseConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/kafka/IdenthendelseConsumerService.kt
@@ -18,7 +18,7 @@ class IdenthendelseConsumerService(
 ) : KafkaConsumerService<GenericRecord> {
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
         runBlocking {
             try {
                 val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))

--- a/src/main/kotlin/no/nav/syfo/pdlpersonhendelse/kafka/KafkaPersonhendelseConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdlpersonhendelse/kafka/KafkaPersonhendelseConsumerService.kt
@@ -14,7 +14,7 @@ class KafkaPersonhendelseConsumerService(
 ) : KafkaConsumerService<Personhendelse> {
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, Personhendelse>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, Personhendelse>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             processRecords(records)

--- a/src/main/kotlin/no/nav/syfo/personoppgavehendelse/kafka/PersonoppgavehendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgavehendelse/kafka/PersonoppgavehendelseConsumer.kt
@@ -10,7 +10,7 @@ class PersonoppgavehendelseConsumer(
 ) : KafkaConsumerService<KPersonoppgavehendelse> {
     override val pollDurationInMillis: Long = 100
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KPersonoppgavehendelse>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KPersonoppgavehendelse>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
 
         if (records.count() > 0) {

--- a/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/PersonoversiktStatusService.kt
@@ -6,12 +6,12 @@ import no.nav.syfo.personoppgavehendelse.kafka.COUNT_KAFKA_CONSUMER_PERSONOPPGAV
 import no.nav.syfo.personoppgavehendelse.kafka.COUNT_KAFKA_CONSUMER_PERSONOPPGAVEHENDELSE_READ
 import no.nav.syfo.personoppgavehendelse.kafka.COUNT_KAFKA_CONSUMER_PERSONOPPGAVEHENDELSE_UPDATED_PERSONOVERSIKT_STATUS
 import no.nav.syfo.personoppgavehendelse.kafka.KPersonoppgavehendelse
+import no.nav.syfo.personstatus.application.IPdlClient
 import no.nav.syfo.personstatus.application.IPersonOversiktStatusRepository
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.personstatus.domain.*
 import no.nav.syfo.personstatus.infrastructure.METRICS_NS
 import no.nav.syfo.personstatus.infrastructure.METRICS_REGISTRY
-import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.fodselsdato
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.fullName
 import no.nav.syfo.personstatus.infrastructure.database.DatabaseInterface
@@ -20,7 +20,7 @@ import java.sql.Connection
 
 class PersonoversiktStatusService(
     private val database: DatabaseInterface,
-    private val pdlClient: PdlClient,
+    private val pdlClient: IPdlClient,
     private val personoversiktStatusRepository: IPersonOversiktStatusRepository,
 ) {
     private val isUbehandlet = true
@@ -79,9 +79,7 @@ class PersonoversiktStatusService(
         }
     }
 
-    fun createOrUpdatePersonoversiktStatuser(
-        personoppgavehendelser: List<KPersonoppgavehendelse>,
-    ) {
+    fun createOrUpdatePersonoversiktStatuser(personoppgavehendelser: List<KPersonoppgavehendelse>) {
         database.connection.use { connection ->
             personoppgavehendelser.forEach { personoppgavehendelse ->
                 val personident = PersonIdent(personoppgavehendelse.personident)

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPdlClient.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.personstatus.application
+
+import no.nav.syfo.personstatus.domain.PersonIdent
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlHentPersonBolkData
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlIdenter
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlPerson
+
+interface IPdlClient {
+    suspend fun getPersons(callId: String? = null, personidenter: List<PersonIdent>): PdlHentPersonBolkData?
+    suspend fun getPerson(personIdent: PersonIdent): Result<PdlPerson>
+    suspend fun hentIdenter(nyPersonIdent: String, callId: String? = null): PdlIdenter?
+    suspend fun getPdlPersonIdentNumberNavnMap(callId: String, personIdentList: List<PersonIdent>): Map<String, String>
+}

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/pdl/PdlClient.kt
@@ -5,18 +5,23 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import no.nav.syfo.personstatus.application.IPdlClient
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.infrastructure.clients.ClientEnvironment
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.personstatus.infrastructure.clients.httpClientDefault
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlHentPersonBolkData
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlHentPersonRequest
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlHentPersonRequestVariables
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlIdentRequest
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlIdentResponse
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlIdentVariables
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlIdenter
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlPerson
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlPersonBolkRequest
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlPersonBolkResponse
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlPersonBolkVariables
+import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.PdlHentPersonResponse
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.errorMessage
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.fullName
 import no.nav.syfo.util.*
@@ -26,11 +31,11 @@ class PdlClient(
     private val azureAdClient: AzureAdClient,
     private val clientEnvironment: ClientEnvironment,
     private val httpClient: HttpClient = httpClientDefault(),
-) {
+) : IPdlClient {
 
-    suspend fun hentIdenter(
+    override suspend fun hentIdenter(
         nyPersonIdent: String,
-        callId: String? = null,
+        callId: String?,
     ): PdlIdenter? {
         val systemToken = azureAdClient.getSystemToken(clientEnvironment.clientId)
             ?: throw RuntimeException("Failed to send request to PDL: No token was found")
@@ -70,7 +75,7 @@ class PdlClient(
         }
     }
 
-    suspend fun getPdlPersonIdentNumberNavnMap(
+    override suspend fun getPdlPersonIdentNumberNavnMap(
         callId: String,
         personIdentList: List<PersonIdent>,
     ): Map<String, String> =
@@ -84,8 +89,8 @@ class PdlClient(
             }
             ?: emptyMap()
 
-    suspend fun getPersons(
-        callId: String? = null,
+    override suspend fun getPersons(
+        callId: String?,
         personidenter: List<PersonIdent>,
     ): PdlHentPersonBolkData? {
         val token = azureAdClient.getSystemToken(clientEnvironment.clientId)
@@ -129,6 +134,40 @@ class PdlClient(
                 COUNT_CALL_PDL_PERSONBOLK_FAIL.increment()
                 logger.error("Request with url: ${clientEnvironment.baseUrl} failed with reponse code ${response.status.value}")
                 return null
+            }
+        }
+    }
+
+    override suspend fun getPerson(personIdent: PersonIdent): Result<PdlPerson> {
+        val token = azureAdClient.getSystemToken(clientEnvironment.clientId)
+            ?: throw RuntimeException("Failed to send request to PDL: No token was found")
+        val query = getPdlQuery("/pdl/hentPerson.graphql")
+        val request = PdlHentPersonRequest(query, PdlHentPersonRequestVariables(personIdent.value))
+
+        val response: HttpResponse = httpClient.post(clientEnvironment.baseUrl) {
+            setBody(request)
+            header(HttpHeaders.ContentType, "application/json")
+            header(HttpHeaders.Authorization, bearerHeader(token.accessToken))
+            header(BEHANDLINGSNUMMER_HEADER_KEY, BEHANDLINGSNUMMER_HEADER_VALUE)
+        }
+
+        when (response.status) {
+            HttpStatusCode.OK -> {
+                val pdlPersonReponse = response.body<PdlHentPersonResponse>()
+                val isErrors = !pdlPersonReponse.errors.isNullOrEmpty()
+                if (isErrors) {
+                    pdlPersonReponse.errors.forEach {
+                        logger.error("Error while requesting person from PersonDataLosningen: ${it.errorMessage()}")
+                    }
+                }
+                return pdlPersonReponse.data?.hentPerson
+                    ?.let { Result.success(it) }
+                    ?: Result.failure(RuntimeException("No person found in PDL response"))
+            }
+
+            else -> {
+                logger.error("Request with url: ${clientEnvironment.baseUrl} failed with reponse code ${response.status.value}")
+                return Result.failure(RuntimeException("Failed to get person from PDL"))
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/pdl/model/PdlHentPerson.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/pdl/model/PdlHentPerson.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.personstatus.infrastructure.clients.pdl.model
+
+data class PdlHentPersonRequest(
+    val query: String,
+    val variables: PdlHentPersonRequestVariables,
+)
+
+data class PdlHentPersonRequestVariables(
+    val ident: String,
+)
+
+data class PdlHentPersonResponse(
+    val errors: List<PdlError>?,
+    val data: PdlHentPerson?,
+)
+
+data class PdlHentPerson(
+    val hentPerson: PdlPerson?,
+)

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/pdl/model/PdlPersonBolkResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/pdl/model/PdlPersonBolkResponse.kt
@@ -12,10 +12,10 @@ data class PdlPersonBolkResponse(
 )
 
 data class PdlHentPersonBolkData(
-    val hentPersonBolk: List<PdlHentPerson>?,
+    val hentPersonBolk: List<PdlHentPersonBolkResult>?,
 )
 
-data class PdlHentPerson(
+data class PdlHentPersonBolkResult(
     val ident: String,
     val person: PdlPerson?,
     val code: String,

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingConsumer.kt
@@ -19,7 +19,7 @@ class ArbeidsuforhetvurderingConsumer(
 
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, ArbeidsuforhetvurderingRecord>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, ArbeidsuforhetvurderingRecord>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             log.info("ArbeidsuforhetvurderingConsumer trace: Received ${records.count()} records")

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaConsumerService.kt
@@ -4,7 +4,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 
 interface KafkaConsumerService<ConsumerRecordValue> {
     val pollDurationInMillis: Long
-    fun pollAndProcessRecords(
+    suspend fun pollAndProcessRecords(
         kafkaConsumer: KafkaConsumer<String, ConsumerRecordValue>,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumer.kt
@@ -19,7 +19,7 @@ class ManglendeMedvirkningVurderingConsumer(
 ) : KafkaConsumerService<VurderingRecord> {
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, VurderingRecord>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, VurderingRecord>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             log.info("ManglendeMedvirkningVurderingConsumer trace: Received ${records.count()} records")

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumer.kt
@@ -20,7 +20,7 @@ class SenOppfolgingKandidatStatusConsumer(
 
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KandidatStatusRecord>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KandidatStatusRecord>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             log.info("SenOppfolgingKandidatStatusConsumer trace: Received ${records.count()} records")

--- a/src/main/kotlin/no/nav/syfo/trengeroppfolging/kafka/TrengerOppfolgingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/trengeroppfolging/kafka/TrengerOppfolgingConsumer.kt
@@ -7,12 +7,12 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import java.time.Duration
 
 class TrengerOppfolgingConsumer(
-    private val trengerOppfolgingService: TrengerOppfolgingService
+    private val trengerOppfolgingService: TrengerOppfolgingService,
 ) : KafkaConsumerService<KafkaHuskelapp> {
 
     override val pollDurationInMillis: Long = 1000
 
-    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KafkaHuskelapp>) {
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KafkaHuskelapp>) {
         val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
         if (records.count() > 0) {
             processRecords(records)

--- a/src/main/resources/pdl/hentPerson.graphql
+++ b/src/main/resources/pdl/hentPerson.graphql
@@ -1,0 +1,12 @@
+query($ident: ID!){
+    hentPerson(ident: $ident) {
+        navn(historikk: false) {
+            fornavn
+            mellomnavn
+            etternavn
+        }
+        foedselsdato {
+            foedselsdato
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/AktivitetskravVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskravvurdering/kafka/AktivitetskravVurderingConsumerSpek.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.aktivitetskravvurdering.kafka
 
 import io.ktor.server.testing.*
 import io.mockk.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.aktivitetskravvurdering.domain.AktivitetskravStatus
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.db.*
@@ -70,7 +71,7 @@ class AktivitetskravVurderingConsumerSpek : Spek({
                     )
                 )
 
-                aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock)
+                runBlocking { aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock) }
                 verify(exactly = 1) { consumerMock.commitSync() }
 
                 val pPersonOversiktStatusList =
@@ -106,8 +107,7 @@ class AktivitetskravVurderingConsumerSpek : Spek({
                         kafkaOppfolgingstilfelle
                     )
                 )
-
-                aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock)
+                runBlocking { aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock) }
                 verify(exactly = 1) { consumerMock.commitSync() }
 
                 val pPersonOversiktStatusList =
@@ -136,8 +136,7 @@ class AktivitetskravVurderingConsumerSpek : Spek({
                 val personstatusBeforeConsuming =
                     database.connection.use { it.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR) }.first()
                 personstatusBeforeConsuming.isAktivAktivitetskravvurdering shouldBe false
-
-                aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock)
+                runBlocking { aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock) }
                 verify(exactly = 1) { consumerMock.commitSync() }
 
                 val personstatus = database.connection.use { it.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR) }.first()
@@ -160,7 +159,7 @@ class AktivitetskravVurderingConsumerSpek : Spek({
                     recordValue = aktivitetskravVurderingOppfylt,
                     topic = AKTIVITETSKRAV_VURDERING_TOPIC,
                 )
-                aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock)
+                runBlocking { aktivitetskravVurderingConsumer.pollAndProcessRecords(kafkaConsumer = consumerMock) }
                 verify(exactly = 1) { consumerMock.commitSync() }
 
                 val pPersonOversiktStatusList = database.connection.use { it.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR) }

--- a/src/test/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek.kt
@@ -96,9 +96,7 @@ object PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek : Spek({
                 }
 
                 it("should not update Virksomhetsnavn of existing PersonOppfolgingstilfelleVirksomhet if motebehovUbehandlet, oppfolgingsplanLPSBistandUbehandlet and dialogmotekandidat are not true)") {
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking { oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson) }
 
                     val recordValue = kafkaOppfolgingstilfellePersonServiceRecordRelevant.value()
 
@@ -155,9 +153,7 @@ object PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek : Spek({
 
                         database.createPersonOversiktStatus(personoversiktStatus)
 
-                        oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                            kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                        )
+                        runBlocking { oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson) }
 
                         val recordValue = kafkaOppfolgingstilfellePersonServiceRecordRelevant.value()
 
@@ -230,12 +226,12 @@ object PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek : Spek({
                             )
                         )
                     )
-                    kafkaDialogmotekandidatEndringService.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring,
-                    )
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking {
+                        kafkaDialogmotekandidatEndringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring)
+                        oppfolgingstilfelleConsumer.pollAndProcessRecords(
+                            kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
+                        )
+                    }
 
                     val recordValue = kafkaOppfolgingstilfellePersonServiceRecordRelevant.value()
 
@@ -295,10 +291,7 @@ object PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek : Spek({
                         personident = personIdentDefault,
                         isAktivVurdering = true,
                     )
-
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking { oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson) }
 
                     val recordValue = kafkaOppfolgingstilfellePersonServiceRecordRelevant.value()
 
@@ -377,9 +370,7 @@ object PersonOppfolgingstilfelleVirksomhetsnavnCronjobSpek : Spek({
 
                     database.createPersonOversiktStatus(personoversiktStatus)
 
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking { oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson) }
 
                     runBlocking {
                         val result = personOppfolgingstilfelleVirksomhetnavnCronjob.runJob()

--- a/src/test/kotlin/no/nav/syfo/dialogmotekandidat/kafka/KafkaDialogmotekandidatEndringServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotekandidat/kafka/KafkaDialogmotekandidatEndringServiceSpek.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.dialogmotekandidat.kafka
 
 import io.ktor.server.testing.*
 import io.mockk.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.generator.*
@@ -55,9 +56,9 @@ class KafkaDialogmotekandidatEndringServiceSpek : Spek({
                     )
                 )
 
-                kafkaDialogmotekandidatEndringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring
-                )
+                runBlocking {
+                    kafkaDialogmotekandidatEndringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmotekandidatEndring.commitSync()
@@ -94,9 +95,9 @@ class KafkaDialogmotekandidatEndringServiceSpek : Spek({
                     personOversiktStatus = kafkaOppfolgingstilfellePerson.toPersonOversiktStatus(kafkaOppfolgingstilfelle)
                 )
 
-                kafkaDialogmotekandidatEndringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring
-                )
+                runBlocking {
+                    kafkaDialogmotekandidatEndringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmotekandidatEndring.commitSync()
@@ -127,10 +128,9 @@ class KafkaDialogmotekandidatEndringServiceSpek : Spek({
                 database.createPersonOversiktStatus(
                     personOversiktStatus = existingPersonOversiktStatus
                 )
-
-                kafkaDialogmotekandidatEndringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring
-                )
+                runBlocking {
+                    kafkaDialogmotekandidatEndringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmotekandidatEndring.commitSync()
@@ -158,10 +158,9 @@ class KafkaDialogmotekandidatEndringServiceSpek : Spek({
                 database.createPersonOversiktStatus(
                     personOversiktStatus = existingPersonOversiktStatus
                 )
-
-                kafkaDialogmotekandidatEndringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring
-                )
+                runBlocking {
+                    kafkaDialogmotekandidatEndringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmotekandidatEndring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmotekandidatEndring.commitSync()

--- a/src/test/kotlin/no/nav/syfo/dialogmotestatusendring/kafka/KafkaDialogmoteStatusendringServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotestatusendring/kafka/KafkaDialogmoteStatusendringServiceSpek.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.dialogmotestatusendring.kafka
 
 import io.ktor.server.testing.*
 import io.mockk.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.dialogmotestatusendring.domain.DialogmoteStatusendring
 import no.nav.syfo.dialogmotestatusendring.domain.DialogmoteStatusendringType
 import no.nav.syfo.personstatus.db.*
@@ -59,9 +60,9 @@ class KafkaDialogmoteStatusendringServiceSpek : Spek({
                     )
                 )
 
-                kafkaDialogmoteStatusendringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring
-                )
+                runBlocking {
+                    kafkaDialogmoteStatusendringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmoteStatusendring.commitSync()
@@ -99,9 +100,9 @@ class KafkaDialogmoteStatusendringServiceSpek : Spek({
                     personOversiktStatus = kafkaOppfolgingstilfellePerson.toPersonOversiktStatus(kafkaOppfolgingstilfelle)
                 )
 
-                kafkaDialogmoteStatusendringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring
-                )
+                runBlocking {
+                    kafkaDialogmoteStatusendringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmoteStatusendring.commitSync()
@@ -135,9 +136,9 @@ class KafkaDialogmoteStatusendringServiceSpek : Spek({
                     personOversiktStatus = existingPersonOversiktStatus
                 )
 
-                kafkaDialogmoteStatusendringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring
-                )
+                runBlocking {
+                    kafkaDialogmoteStatusendringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmoteStatusendring.commitSync()
@@ -169,9 +170,9 @@ class KafkaDialogmoteStatusendringServiceSpek : Spek({
                     personOversiktStatus = existingPersonOversiktStatus
                 )
 
-                kafkaDialogmoteStatusendringService.pollAndProcessRecords(
-                    kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring
-                )
+                runBlocking {
+                    kafkaDialogmoteStatusendringService.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerDialogmoteStatusendring)
+                }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerDialogmoteStatusendring.commitSync()

--- a/src/test/kotlin/no/nav/syfo/frisktilarbeid/kafka/KafkaFriskTilArbeidServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/frisktilarbeid/kafka/KafkaFriskTilArbeidServiceSpek.kt
@@ -4,6 +4,7 @@ import io.ktor.server.testing.*
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.testutil.*
@@ -60,9 +61,9 @@ class KafkaFriskTilArbeidServiceSpek : Spek({
                     )
                 )
 
-                kafkaFriskTilArbeidService.pollAndProcessRecords(
-                    kafkaConsumer = kafkaConsumerFriskTilArbeid,
-                )
+                runBlocking {
+                    kafkaFriskTilArbeidService.pollAndProcessRecords(kafkaConsumer = kafkaConsumerFriskTilArbeid)
+                }
 
                 verify(exactly = 1) {
                     kafkaConsumerFriskTilArbeid.commitSync()
@@ -96,9 +97,9 @@ class KafkaFriskTilArbeidServiceSpek : Spek({
                     personOversiktStatus = kafkaOppfolgingstilfellePerson.toPersonOversiktStatus(kafkaOppfolgingstilfelle)
                 )
 
-                kafkaFriskTilArbeidService.pollAndProcessRecords(
-                    kafkaConsumer = kafkaConsumerFriskTilArbeid,
-                )
+                runBlocking {
+                    kafkaFriskTilArbeidService.pollAndProcessRecords(kafkaConsumer = kafkaConsumerFriskTilArbeid)
+                }
 
                 verify(exactly = 1) {
                     kafkaConsumerFriskTilArbeid.commitSync()
@@ -120,9 +121,9 @@ class KafkaFriskTilArbeidServiceSpek : Spek({
                         )
                     )
                 )
-                kafkaFriskTilArbeidService.pollAndProcessRecords(
-                    kafkaConsumer = kafkaConsumerFriskTilArbeid,
-                )
+                runBlocking {
+                    kafkaFriskTilArbeidService.pollAndProcessRecords(kafkaConsumer = kafkaConsumerFriskTilArbeid)
+                }
                 clearMocks(kafkaConsumerFriskTilArbeid)
                 every { kafkaConsumerFriskTilArbeid.commitSync() } returns Unit
 
@@ -144,9 +145,9 @@ class KafkaFriskTilArbeidServiceSpek : Spek({
                     )
                 )
 
-                kafkaFriskTilArbeidService.pollAndProcessRecords(
-                    kafkaConsumer = kafkaConsumerFriskTilArbeid,
-                )
+                runBlocking {
+                    kafkaFriskTilArbeidService.pollAndProcessRecords(kafkaConsumer = kafkaConsumerFriskTilArbeid)
+                }
 
                 verify(exactly = 1) {
                     kafkaConsumerFriskTilArbeid.commitSync()

--- a/src/test/kotlin/no/nav/syfo/personoppgavehendelse/kafka/PersonoppgavehendelseConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personoppgavehendelse/kafka/PersonoppgavehendelseConsumerSpek.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.personoppgavehendelse.kafka
 
 import io.ktor.util.*
 import io.mockk.every
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.domain.*
 import no.nav.syfo.personstatus.db.*
 import no.nav.syfo.testutil.*
@@ -41,8 +42,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
 
         it("Create personoversiktstatus on read from topic personoppgavehendelser") {
             mockReceiveHendelse(lpsbistandMottatt, mockPersonoppgavehendelseConsumer)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -56,7 +58,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
                 .applyHendelse(OversikthendelseType.OPPFOLGINGSPLANLPS_BISTAND_MOTTATT)
             database.createPersonOversiktStatus(personOversiktStatus)
 
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -73,8 +77,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
             val personOversiktStatus = PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR)
                 .applyHendelse(OversikthendelseType.DIALOGMOTESVAR_MOTTATT)
             database.createPersonOversiktStatus(personOversiktStatus)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -88,8 +93,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
                 hendelsetype = OversikthendelseType.BEHANDLERDIALOG_SVAR_MOTTATT,
             )
             mockReceiveHendelse(behandlerdialogSvarMottatt, mockPersonoppgavehendelseConsumer)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -106,8 +112,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
             val personOversiktStatus = PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR)
                 .applyHendelse(OversikthendelseType.BEHANDLERDIALOG_SVAR_MOTTATT)
             database.createPersonOversiktStatus(personOversiktStatus)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -121,8 +128,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
                 hendelsetype = OversikthendelseType.BEHANDLERDIALOG_MELDING_UBESVART_MOTTATT,
             )
             mockReceiveHendelse(behandlerdialogUbesvartMottatt, mockPersonoppgavehendelseConsumer)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -139,8 +147,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
             val personOversiktStatus = PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR)
                 .applyHendelse(OversikthendelseType.BEHANDLERDIALOG_MELDING_UBESVART_MOTTATT)
             database.createPersonOversiktStatus(personOversiktStatus)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -154,8 +163,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
                 hendelsetype = OversikthendelseType.BEHANDLERDIALOG_MELDING_AVVIST_MOTTATT,
             )
             mockReceiveHendelse(behandlerdialogAvvistMottatt, mockPersonoppgavehendelseConsumer)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -171,8 +181,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
             val personOversiktStatus = PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR)
                 .applyHendelse(OversikthendelseType.BEHANDLERDIALOG_MELDING_AVVIST_MOTTATT)
             database.createPersonOversiktStatus(personOversiktStatus)
-
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -184,7 +195,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
                 generateKPersonoppgavehendelse(OversikthendelseType.BEHANDLER_BER_OM_BISTAND_MOTTATT)
             mockReceiveHendelse(behandlerBistandHendelseMottatt, mockPersonoppgavehendelseConsumer)
 
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -199,7 +212,9 @@ object PersonoppgavehendelseServiceSpek : Spek({
                 .applyHendelse(OversikthendelseType.BEHANDLER_BER_OM_BISTAND_MOTTATT)
             database.createPersonOversiktStatus(personOversiktStatus)
 
-            personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            runBlocking {
+                personoppgavehendelseConsumer.pollAndProcessRecords(kafkaConsumer = mockPersonoppgavehendelseConsumer)
+            }
 
             val personoversiktStatuser = database.getPersonOversiktStatusList(UserConstants.ARBEIDSTAKER_FNR)
             val firstStatus = personoversiktStatuser.first()
@@ -210,7 +225,7 @@ object PersonoppgavehendelseServiceSpek : Spek({
 
 fun mockReceiveHendelse(
     hendelse: KPersonoppgavehendelse,
-    mockKafkaPersonoppgavehendelse: KafkaConsumer<String, KPersonoppgavehendelse>
+    mockKafkaPersonoppgavehendelse: KafkaConsumer<String, KPersonoppgavehendelse>,
 ) {
     every { mockKafkaPersonoppgavehendelse.poll(any<Duration>()) } returns ConsumerRecords(
         mapOf(

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -230,9 +230,9 @@ object PersonoversiktStatusApiV2Spek : Spek({
                 }
 
                 it("should return NoContent, if there is a person with a relevant active Oppfolgingstilfelle, but neither MOTEBEHOV_SVAR_MOTTATT nor DIALOGMOTEKANDIDAT") {
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking {
+                        oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson)
+                    }
                     runBlocking {
                         personOppfolgingstilfelleVirksomhetnavnCronjob.runJob()
                     }
@@ -251,9 +251,9 @@ object PersonoversiktStatusApiV2Spek : Spek({
                 }
 
                 it("should return list of PersonOversiktStatus, if MOTEBEHOV_SVAR_MOTTATT and OPPFOLGINGSPLANLPS_BISTAND_MOTTATT and DIALOGMOTESVAR_MOTTATT, and there is a person with a relevant active Oppfolgingstilfelle") {
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking {
+                        oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson)
+                    }
                     val oversiktHendelse = KPersonoppgavehendelse(
                         ARBEIDSTAKER_FNR,
                         OversikthendelseType.MOTEBEHOV_SVAR_MOTTATT,
@@ -310,9 +310,9 @@ object PersonoversiktStatusApiV2Spek : Spek({
                 }
 
                 it("should return list of PersonOversiktStatus, if MOTEBEHOV_SVAR_MOTTATT and if there is a person with 2 relevant active Oppfolgingstilfelle with different virksomhetsnummer") {
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking {
+                        oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson)
+                    }
                     val oversiktHendelse = KPersonoppgavehendelse(
                         ARBEIDSTAKER_FNR,
                         OversikthendelseType.MOTEBEHOV_SVAR_MOTTATT,
@@ -368,11 +368,8 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     personoversiktStatusService.createOrUpdatePersonoversiktStatuser(
                         personoppgavehendelser = listOf(oversiktHendelse, oversiktHendelseOPLPSBistandMottatt)
                     )
-
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
                     runBlocking {
+                        oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson)
                         personOppfolgingstilfelleVirksomhetnavnCronjob.runJob()
                     }
 
@@ -411,9 +408,9 @@ object PersonoversiktStatusApiV2Spek : Spek({
                 }
 
                 it("should return Person, receives Oppfolgingstilfelle, and then MOTEBEHOV_SVAR_MOTTATT and OPPFOLGINGSPLANLPS_BISTAND_MOTTATT") {
-                    oppfolgingstilfelleConsumer.pollAndProcessRecords(
-                        kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson,
-                    )
+                    runBlocking {
+                        oppfolgingstilfelleConsumer.pollAndProcessRecords(kafkaConsumer = mockKafkaConsumerOppfolgingstilfellePerson)
+                    }
 
                     val oversiktHendelse = KPersonoppgavehendelse(
                         ARBEIDSTAKER_FNR,

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/ArbeidsuforhetvurderingConsumerSpek.kt
@@ -4,6 +4,7 @@ import io.mockk.*
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
@@ -67,7 +68,9 @@ class ArbeidsuforhetvurderingConsumerSpek : Spek({
                 topic = "teamsykefravr.arbeidsuforhet-vurdering",
             )
 
-            arbeidsuforhetvurderingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumer)
+            runBlocking {
+                arbeidsuforhetvurderingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumer)
+            }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
@@ -4,6 +4,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
 import no.nav.syfo.personstatus.domain.PersonIdent
@@ -69,7 +70,7 @@ class ManglendeMedvirkningVurderingConsumerSpek : Spek({
                 topic = "teamsykefravr.manglende-medvirkning-vurdering",
             )
 
-            manglendeMedvirkningConsumer.pollAndProcessRecords(kafkaConsumer)
+            runBlocking { manglendeMedvirkningConsumer.pollAndProcessRecords(kafkaConsumer) }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()
@@ -103,7 +104,7 @@ class ManglendeMedvirkningVurderingConsumerSpek : Spek({
                 topic = "teamsykefravr.manglende-medvirkning-vurdering",
             )
 
-            manglendeMedvirkningConsumer.pollAndProcessRecords(kafkaConsumer)
+            runBlocking { manglendeMedvirkningConsumer.pollAndProcessRecords(kafkaConsumer) }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()
@@ -130,7 +131,7 @@ class ManglendeMedvirkningVurderingConsumerSpek : Spek({
                 topic = "teamsykefravr.manglende-medvirkning-vurdering",
             )
 
-            manglendeMedvirkningConsumer.pollAndProcessRecords(kafkaConsumer)
+            runBlocking { manglendeMedvirkningConsumer.pollAndProcessRecords(kafkaConsumer) }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumerSpek.kt
@@ -4,6 +4,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.personstatus.PersonoversiktStatusService
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
 import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
@@ -60,7 +61,7 @@ class SenOppfolgingKandidatStatusConsumerSpek : Spek({
                 topic = SenOppfolgingKandidatStatusConsumer.SEN_OPPFOLGING_KANDIDAT_STATUS_TOPIC,
             )
 
-            senOppfolgingKandidatStatusConsumer.pollAndProcessRecords(kafkaConsumer)
+            runBlocking { senOppfolgingKandidatStatusConsumer.pollAndProcessRecords(kafkaConsumer) }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()
@@ -84,7 +85,7 @@ class SenOppfolgingKandidatStatusConsumerSpek : Spek({
                 topic = SenOppfolgingKandidatStatusConsumer.SEN_OPPFOLGING_KANDIDAT_STATUS_TOPIC,
             )
 
-            senOppfolgingKandidatStatusConsumer.pollAndProcessRecords(kafkaConsumer)
+            runBlocking { senOppfolgingKandidatStatusConsumer.pollAndProcessRecords(kafkaConsumer) }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()
@@ -117,7 +118,7 @@ class SenOppfolgingKandidatStatusConsumerSpek : Spek({
                 topic = SenOppfolgingKandidatStatusConsumer.SEN_OPPFOLGING_KANDIDAT_STATUS_TOPIC,
             )
 
-            senOppfolgingKandidatStatusConsumer.pollAndProcessRecords(kafkaConsumer)
+            runBlocking { senOppfolgingKandidatStatusConsumer.pollAndProcessRecords(kafkaConsumer) }
 
             verify(exactly = 1) {
                 kafkaConsumer.commitSync()

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -44,6 +44,7 @@ class ExternalMockEnvironment private constructor() {
     )
 
     val oppfolgingstilfelleService = OppfolgingstilfelleService(
+        pdlClient = pdlClient,
         personOversiktStatusRepository = personOversiktStatusRepository,
     )
 

--- a/src/test/kotlin/no/nav/syfo/trengeroppfolging/kafka/TrengerOppfolgingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/trengeroppfolging/kafka/TrengerOppfolgingConsumerSpek.kt
@@ -5,6 +5,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.trengeroppfolging.TrengerOppfolgingService
 import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus
@@ -53,9 +54,7 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking { trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock) }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -75,9 +74,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -97,9 +96,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -118,9 +117,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -140,9 +139,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -167,9 +166,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -196,9 +195,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()
@@ -225,9 +224,9 @@ class TrengerOppfolgingConsumerSpek : Spek({
                         kafkaConsumerMock = kafkaConsumerMock,
                     )
 
-                    trengerOppfolgingConsumer.pollAndProcessRecords(
-                        kafkaConsumer = kafkaConsumerMock,
-                    )
+                    runBlocking {
+                        trengerOppfolgingConsumer.pollAndProcessRecords(kafkaConsumer = kafkaConsumerMock)
+                    }
 
                     verify(exactly = 1) {
                         kafkaConsumerMock.commitSync()


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til at vi henter navn og fødselsdato fra PDL første gang en person kommer inn som et oppfølgingstilfelle.
- Siden dette kallet henter en enkeltperson trenger vi å bruke et nytt endepunkt(?) fra pdl

Teknisk:
- For å hente fra PDL endret jeg `pollAndProcessRecords` til en `suspend` funksjon som gjør at det måtte oppdateres masse steder i testene. Derfor litt stor PR.

- [x] Test i dev