### PR TITLE
IS-2824: Set arbeidsuforhet vurdering to inactive due to wrong vurdering

### DIFF
--- a/src/main/resources/db/migration/V18_07__fix_aktiv_arbeidsuførhet_vurdering.sql
+++ b/src/main/resources/db/migration/V18_07__fix_aktiv_arbeidsuførhet_vurdering.sql
@@ -1,0 +1,3 @@
+UPDATE person_oversikt_status
+SET arbeidsuforhet_aktiv_vurdering = false
+WHERE uuid = '46c5c7ea-d82b-4dca-80de-ae84a439c188';


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Setter arbeidsuforhet vurdering til inaktiv. 
- Ses i sammenheng med [denne](https://github.com/navikt/isarbeidsuforhet/pull/107#issuecomment-2500375985)
