### PR TITLE
Remove logging, counting and update name in db from api call

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktStatusService.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.personstatus.application
 
-import io.micrometer.core.instrument.Counter
 import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personoppgavehendelse.kafka.COUNT_KAFKA_CONSUMER_PERSONOPPGAVEHENDELSE_CREATED_PERSONOVERSIKT_STATUS
 import no.nav.syfo.personoppgavehendelse.kafka.COUNT_KAFKA_CONSUMER_PERSONOPPGAVEHENDELSE_READ
@@ -17,19 +16,15 @@ import no.nav.syfo.personstatus.db.updatePersonOversiktStatusBehandlerdialogSvar
 import no.nav.syfo.personstatus.db.updatePersonOversiktStatusBehandlerdialogUbesvart
 import no.nav.syfo.personstatus.db.updatePersonOversiktStatusDialogmotesvar
 import no.nav.syfo.personstatus.db.updatePersonOversiktStatusLPS
-import no.nav.syfo.personstatus.db.updatePersonOversiktStatusNavn
 import no.nav.syfo.personstatus.domain.*
 import no.nav.syfo.personstatus.domain.addPersonName
 import no.nav.syfo.personstatus.domain.applyHendelse
 import no.nav.syfo.personstatus.domain.hasActiveOppgave
 import no.nav.syfo.personstatus.domain.toPersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personstatus.domain.toPersonOversiktStatus
-import no.nav.syfo.personstatus.infrastructure.METRICS_NS
-import no.nav.syfo.personstatus.infrastructure.METRICS_REGISTRY
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.fodselsdato
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.model.fullName
 import no.nav.syfo.personstatus.infrastructure.database.DatabaseInterface
-import org.slf4j.LoggerFactory
 import java.sql.Connection
 import kotlin.collections.associateBy
 import kotlin.collections.filter
@@ -38,7 +33,6 @@ import kotlin.collections.forEach
 import kotlin.collections.map
 import kotlin.collections.mapNotNull
 import kotlin.collections.mapValues
-import kotlin.jvm.java
 import kotlin.text.isNullOrEmpty
 import kotlin.use
 
@@ -92,13 +86,10 @@ class PersonoversiktStatusService(
         return if (personIdentMissingNameList.isEmpty()) {
             personOversiktStatusList
         } else {
-            log.info("Got ${personIdentMissingNameList.size} personoversikt statuses with missing names. Get names from PDL and update database...")
-            COUNT_GET_PERSONOVERSIKT_MISSING_NAMES.increment()
             val personIdentNavnMap = pdlClient.getPdlPersonIdentNumberNavnMap(
                 callId = callId,
                 personIdentList = personIdentMissingNameList,
             )
-            database.updatePersonOversiktStatusNavn(personIdentNavnMap)
             personOversiktStatusList.addPersonName(personIdentNameMap = personIdentNavnMap)
         }
     }
@@ -221,13 +212,5 @@ class PersonoversiktStatusService(
 
             COUNT_KAFKA_CONSUMER_PERSONOPPGAVEHENDELSE_UPDATED_PERSONOVERSIKT_STATUS.increment()
         }
-    }
-
-    companion object {
-        private val log = LoggerFactory.getLogger(this::class.java)
-        private const val GET_PERSONOVERSIKT_MISSING_NAMES = "${METRICS_NS}_get_personoversikt_missing_names"
-        val COUNT_GET_PERSONOVERSIKT_MISSING_NAMES: Counter = Counter.builder(GET_PERSONOVERSIKT_MISSING_NAMES)
-            .description("Counts the number of times personoversikt statuses has any missing names")
-            .register(METRICS_REGISTRY)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -328,7 +328,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         oppfolgingstilfelle: Oppfolgingstilfelle,
     ) {
         database.connection.use { connection ->
-            val personstatusId = connection.prepareStatement(queryUpdatePersonOversiktStatusOppfolgingstilfelle).use {
+            val personstatusId = connection.prepareStatement(UPDATE_PERSON_OPPFOLGINGSTILFELLE).use {
                 it.setObject(1, oppfolgingstilfelle.updatedAt)
                 it.setObject(2, oppfolgingstilfelle.generatedAt)
                 it.setObject(3, oppfolgingstilfelle.oppfolgingstilfelleStart)
@@ -508,6 +508,21 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             SET name = ?, fodselsdato = ?, sist_endret = ?
             WHERE fnr = ?
             RETURNING *
+            """
+
+        private const val UPDATE_PERSON_OPPFOLGINGSTILFELLE =
+            """
+            UPDATE PERSON_OVERSIKT_STATUS
+            SET oppfolgingstilfelle_updated_at = ?,
+            oppfolgingstilfelle_generated_at = ?,
+            oppfolgingstilfelle_start = ?,
+            oppfolgingstilfelle_end = ?,
+            oppfolgingstilfelle_bit_referanse_uuid = ?,
+            oppfolgingstilfelle_bit_referanse_inntruffet = ?,
+            sist_endret = ?,
+            antall_sykedager = ?
+            WHERE fnr = ?
+            RETURNING id
             """
     }
 }

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -15,7 +15,6 @@ import no.nav.syfo.personstatus.api.v2.endpoints.personOversiktApiV2Path
 import no.nav.syfo.personstatus.api.v2.model.PersonOversiktStatusDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningVurderingType
 import no.nav.syfo.personstatus.db.createPersonOversiktStatus
-import no.nav.syfo.personstatus.db.getPersonOversiktStatusList
 import no.nav.syfo.personstatus.domain.*
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.domain.Virksomhetsnummer
@@ -656,37 +655,6 @@ object PersonoversiktStatusApiV2Spek : Spek({
                         personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
                         personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo yesterday
                     }
-                }
-
-                it("Should update name in database") {
-                    val personIdent = PersonIdent(ARBEIDSTAKER_FNR)
-                    val oversikthendelseDialogmotesvarMottatt = KPersonoppgavehendelse(
-                        ARBEIDSTAKER_FNR,
-                        OversikthendelseType.DIALOGMOTESVAR_MOTTATT,
-                    )
-                    personoversiktStatusService.createOrUpdatePersonoversiktStatuser(
-                        personoppgavehendelser = listOf(oversikthendelseDialogmotesvarMottatt)
-                    )
-
-                    val tilknytning = VeilederBrukerKnytning(VEILEDER_ID, personIdent.value)
-                    database.setTildeltEnhet(
-                        ident = personIdent,
-                        enhet = NAV_ENHET,
-                    )
-                    personOversiktStatusRepository.lagreVeilederForBruker(tilknytning, VEILEDER_ID)
-                    with(
-                        handleRequest(HttpMethod.Get, url) {
-                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                        }
-                    ) {
-                        response.status() shouldBeEqualTo HttpStatusCode.OK
-                        val personOversiktStatus =
-                            objectMapper.readValue<List<PersonOversiktStatusDTO>>(response.content!!).first()
-                        personOversiktStatus.navn shouldBeEqualTo "Fornavn${personIdent.value} Mellomnavn${personIdent.value} Etternavn${personIdent.value}"
-                    }
-
-                    val personOversiktStatusList = database.getPersonOversiktStatusList(personIdent.value)
-                    personOversiktStatusList.first().navn shouldBeEqualTo "Fornavn${personIdent.value} Mellomnavn${personIdent.value} Etternavn${personIdent.value}"
                 }
 
                 it("return person when trenger_oppfolging true") {


### PR DESCRIPTION
Fjerner oppdatering av navn i databasen som gjøres ifm api-kall siden vi nå oppdaterer navn via cronjob og konsumering av oppfølgingstilfeller.
Loggingen som var lagt på her sa at det kommer noen kall hver dag hvor 1-2 personer mangler navn, så for disse må vi fortsatt kalle pdl for å få med navn i responsen til frontend.
