### PR TITLE
IS-2460: Tatt i bruk nytt endepunkt for å hente aktive oppfølgingsoppgaver

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/api/v2/model/PersonOversiktStatusDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/api/v2/model/PersonOversiktStatusDTO.kt
@@ -4,7 +4,7 @@ import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravDTO
 import no.nav.syfo.personstatus.application.arbeidsuforhet.ArbeidsuforhetvurderingDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningDTO
 import no.nav.syfo.personstatus.application.meroppfolging.SenOppfolgingKandidatDTO
-import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveDTO
+import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveLatestVersionDTO
 import java.time.LocalDate
 
 data class PersonOversiktStatusDTO(
@@ -23,7 +23,7 @@ data class PersonOversiktStatusDTO(
     val behandlerBerOmBistandUbehandlet: Boolean,
     val arbeidsuforhetvurdering: ArbeidsuforhetvurderingDTO?,
     val friskmeldingTilArbeidsformidlingFom: LocalDate?,
-    val oppfolgingsoppgave: OppfolgingsoppgaveDTO?,
+    val oppfolgingsoppgave: OppfolgingsoppgaveLatestVersionDTO?,
     val senOppfolgingKandidat: SenOppfolgingKandidatDTO?,
     val aktivitetskravvurdering: AktivitetskravDTO?,
     val manglendeMedvirkning: ManglendeMedvirkningDTO?,

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktAktiveOppgaver.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktAktiveOppgaver.kt
@@ -4,11 +4,11 @@ import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravDTO
 import no.nav.syfo.personstatus.application.arbeidsuforhet.ArbeidsuforhetvurderingDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningDTO
 import no.nav.syfo.personstatus.application.meroppfolging.SenOppfolgingKandidatDTO
-import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveDTO
+import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveLatestVersionDTO
 
 data class PersonoversiktAktiveOppgaver(
     val arbeidsuforhet: ArbeidsuforhetvurderingDTO?,
-    val oppfolgingsoppgave: OppfolgingsoppgaveDTO?,
+    val oppfolgingsoppgave: OppfolgingsoppgaveLatestVersionDTO?,
     val aktivitetskrav: AktivitetskravDTO?,
     val manglendeMedvirkning: ManglendeMedvirkningDTO?,
     val senOppfolgingKandidat: SenOppfolgingKandidatDTO?,

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktOppgaverService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktOppgaverService.kt
@@ -13,7 +13,7 @@ import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvir
 import no.nav.syfo.personstatus.application.meroppfolging.IMeroppfolgingClient
 import no.nav.syfo.personstatus.application.meroppfolging.SenOppfolgingKandidaterResponseDTO
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.IOppfolgingsoppgaveClient
-import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaverResponseDTO
+import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaverLatestVersionResponseDTO
 import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import org.slf4j.LoggerFactory
@@ -129,7 +129,7 @@ class PersonoversiktOppgaverService(
         callId: String,
         token: String,
         personStatuser: List<PersonOversiktStatus>,
-    ): Deferred<OppfolgingsoppgaverResponseDTO?> =
+    ): Deferred<OppfolgingsoppgaverLatestVersionResponseDTO?> =
         CoroutineScope(Dispatchers.IO).async {
             val personidenterWithOppfolgingsoppgave = personStatuser
                 .filter { it.isAktivOppfolgingsoppgave }

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/IOppfolgingsoppgaveClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/IOppfolgingsoppgaveClient.kt
@@ -8,5 +8,5 @@ interface IOppfolgingsoppgaveClient {
         callId: String,
         token: String,
         personidenter: List<PersonIdent>,
-    ): OppfolgingsoppgaverResponseDTO?
+    ): OppfolgingsoppgaverLatestVersionResponseDTO?
 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveDTO.kt
@@ -20,7 +20,7 @@ data class OppfolgingsoppgaveDTO(
     val tekst: String?,
     val oppfolgingsgrunn: String,
     val frist: LocalDate?,
-){
+) {
     companion object {
         fun fromOppfolgingsoppgaveNewDTO(oppfolgingsoppgaveNewDTO: OppfolgingsoppgaveNewDTO): OppfolgingsoppgaveDTO =
             OppfolgingsoppgaveDTO(

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveDTO.kt
@@ -8,11 +8,11 @@ data class OppfolgingsoppgaverRequestDTO(
     val personidenter: List<String>
 )
 
-data class OppfolgingsoppgaverResponseDTO(
-    val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveDTO>
+data class OppfolgingsoppgaverLatestVersionResponseDTO(
+    val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveLatestVersionDTO>
 )
 
-data class OppfolgingsoppgaveDTO(
+data class OppfolgingsoppgaveLatestVersionDTO(
     val uuid: String,
     val createdBy: String,
     val updatedAt: LocalDateTime,
@@ -22,24 +22,24 @@ data class OppfolgingsoppgaveDTO(
     val frist: LocalDate?,
 ) {
     companion object {
-        fun fromOppfolgingsoppgaveNewDTO(oppfolgingsoppgaveNewDTO: OppfolgingsoppgaveNewDTO): OppfolgingsoppgaveDTO =
-            OppfolgingsoppgaveDTO(
-                uuid = oppfolgingsoppgaveNewDTO.uuid,
-                updatedAt = oppfolgingsoppgaveNewDTO.updatedAt,
-                createdAt = oppfolgingsoppgaveNewDTO.createdAt,
-                createdBy = oppfolgingsoppgaveNewDTO.sisteVersjon().createdBy,
-                tekst = oppfolgingsoppgaveNewDTO.sisteVersjon().tekst,
-                oppfolgingsgrunn = oppfolgingsoppgaveNewDTO.sisteVersjon().oppfolgingsgrunn,
-                frist = oppfolgingsoppgaveNewDTO.sisteVersjon().frist
+        fun fromOppfolgingsoppgaveDTO(oppfolgingsoppgaveDTO: OppfolgingsoppgaveDTO): OppfolgingsoppgaveLatestVersionDTO =
+            OppfolgingsoppgaveLatestVersionDTO(
+                uuid = oppfolgingsoppgaveDTO.uuid,
+                updatedAt = oppfolgingsoppgaveDTO.updatedAt,
+                createdAt = oppfolgingsoppgaveDTO.createdAt,
+                createdBy = oppfolgingsoppgaveDTO.sisteVersjon().createdBy,
+                tekst = oppfolgingsoppgaveDTO.sisteVersjon().tekst,
+                oppfolgingsgrunn = oppfolgingsoppgaveDTO.sisteVersjon().oppfolgingsgrunn,
+                frist = oppfolgingsoppgaveDTO.sisteVersjon().frist
             )
     }
 }
 
-data class OppfolgingsoppgaverNewResponseDTO(
-    val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveNewDTO>
+data class OppfolgingsoppgaverResponseDTO(
+    val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveDTO>
 )
 
-data class OppfolgingsoppgaveNewDTO(
+data class OppfolgingsoppgaveDTO(
     val uuid: String,
     val personIdent: PersonIdent,
     val createdAt: LocalDateTime,

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.personstatus.application.oppfolgingsoppgave
 
+import no.nav.syfo.personstatus.domain.PersonIdent
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -15,6 +16,45 @@ data class OppfolgingsoppgaveDTO(
     val uuid: String,
     val createdBy: String,
     val updatedAt: LocalDateTime,
+    val createdAt: LocalDateTime,
+    val tekst: String?,
+    val oppfolgingsgrunn: String,
+    val frist: LocalDate?,
+){
+    companion object {
+        fun fromOppfolgingsoppgaveNewDTO(oppfolgingsoppgaveNewDTO: OppfolgingsoppgaveNewDTO): OppfolgingsoppgaveDTO =
+            OppfolgingsoppgaveDTO(
+                uuid = oppfolgingsoppgaveNewDTO.uuid,
+                updatedAt = oppfolgingsoppgaveNewDTO.updatedAt,
+                createdAt = oppfolgingsoppgaveNewDTO.createdAt,
+                createdBy = oppfolgingsoppgaveNewDTO.sisteVersjon().createdBy,
+                tekst = oppfolgingsoppgaveNewDTO.sisteVersjon().tekst,
+                oppfolgingsgrunn = oppfolgingsoppgaveNewDTO.sisteVersjon().oppfolgingsgrunn,
+                frist = oppfolgingsoppgaveNewDTO.sisteVersjon().frist
+            )
+    }
+}
+
+data class OppfolgingsoppgaverNewResponseDTO(
+    val oppfolgingsoppgaver: Map<String, OppfolgingsoppgaveNewDTO>
+)
+
+data class OppfolgingsoppgaveNewDTO(
+    val uuid: String,
+    val personIdent: PersonIdent,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val isActive: Boolean,
+    val publishedAt: LocalDateTime?,
+    val removedBy: String?,
+    val versjoner: List<OppfolgingoppgaveVersjonDTO>
+) {
+    fun sisteVersjon() = versjoner.first()
+}
+
+data class OppfolgingoppgaveVersjonDTO(
+    val uuid: String,
+    val createdBy: String,
     val createdAt: LocalDateTime,
     val tekst: String?,
     val oppfolgingsgrunn: String,

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.personstatus.application.aktivitetskrav.AktivitetskravDTO
 import no.nav.syfo.personstatus.application.arbeidsuforhet.ArbeidsuforhetvurderingDTO
 import no.nav.syfo.personstatus.application.manglendemedvirkning.ManglendeMedvirkningDTO
 import no.nav.syfo.personstatus.application.meroppfolging.SenOppfolgingKandidatDTO
-import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveDTO
+import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveLatestVersionDTO
 import no.nav.syfo.util.isBeforeOrEqual
 import no.nav.syfo.util.toLocalDateOslo
 import java.time.LocalDate
@@ -101,7 +101,7 @@ fun List<PersonOversiktStatus>.addPersonName(
 
 fun PersonOversiktStatus.toPersonOversiktStatusDTO(
     arbeidsuforhetvurdering: ArbeidsuforhetvurderingDTO?,
-    oppfolgingsoppgave: OppfolgingsoppgaveDTO?,
+    oppfolgingsoppgave: OppfolgingsoppgaveLatestVersionDTO?,
     aktivitetskravvurdering: AktivitetskravDTO?,
     manglendeMedvirkning: ManglendeMedvirkningDTO?,
     senOppfolgingKandidat: SenOppfolgingKandidatDTO?,

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/oppfolgingsoppgave/OppfolgingsoppgaveClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/oppfolgingsoppgave/OppfolgingsoppgaveClient.kt
@@ -29,7 +29,7 @@ class OppfolgingsoppgaveClient(
         callId: String,
         token: String,
         personidenter: List<PersonIdent>,
-    ): OppfolgingsoppgaverResponseDTO? {
+    ): OppfolgingsoppgaverLatestVersionResponseDTO? {
         val oboToken = azureAdClient.getOnBehalfOfToken(
             scopeClientId = clientEnvironment.clientId,
             token,
@@ -47,10 +47,10 @@ class OppfolgingsoppgaveClient(
             }
             when (response.status) {
                 HttpStatusCode.OK -> {
-                    val responseDTO = response.body<OppfolgingsoppgaverNewResponseDTO>()
+                    val responseDTO = response.body<OppfolgingsoppgaverResponseDTO>()
                     responseDTO.oppfolgingsoppgaver
-                        .mapValues { OppfolgingsoppgaveDTO.fromOppfolgingsoppgaveNewDTO(it.value) }
-                        .run { OppfolgingsoppgaverResponseDTO(this) }
+                        .mapValues { OppfolgingsoppgaveLatestVersionDTO.fromOppfolgingsoppgaveDTO(it.value) }
+                        .run { OppfolgingsoppgaverLatestVersionResponseDTO(this) }
                 }
                 HttpStatusCode.NoContent -> null
                 HttpStatusCode.NotFound -> {

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -683,6 +683,8 @@ object PersonoversiktStatusApiV2Spek : Spek({
                         personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
                         personOversiktStatus.oppfolgingsoppgave shouldNotBe null
                         personOversiktStatus.oppfolgingsoppgave?.oppfolgingsgrunn shouldBeEqualTo "FOLG_OPP_ETTER_NESTE_SYKMELDING"
+                        personOversiktStatus.oppfolgingsoppgave?.tekst shouldBeEqualTo "En tekst"
+                        personOversiktStatus.oppfolgingsoppgave?.frist shouldNotBe null
                     }
                 }
 

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/OppfolgingsoppgaveMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/OppfolgingsoppgaveMock.kt
@@ -2,8 +2,8 @@ package no.nav.syfo.testutil.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveDTO
-import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaverResponseDTO
+import no.nav.syfo.personstatus.application.oppfolgingsoppgave.*
+import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_2_FNR
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_3_FNR
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
@@ -15,7 +15,7 @@ import java.util.*
 fun MockRequestHandleScope.oppfolgingsoppgaveMockResponse(): HttpResponseData =
     respondOk(oppfolgingsoppgaverResponseDTO)
 
-private val oppfolgingsoppgaverResponseDTO = OppfolgingsoppgaverResponseDTO(
+private val oppfolgingsoppgaverResponseDTO = OppfolgingsoppgaverNewResponseDTO(
     oppfolgingsoppgaver = mapOf(
         ARBEIDSTAKER_FNR to generateOppfolgingsoppgave("FOLG_OPP_ETTER_NESTE_SYKMELDING"),
         ARBEIDSTAKER_2_FNR to generateOppfolgingsoppgave("VURDER_ANNEN_YTELSE"),
@@ -25,12 +25,22 @@ private val oppfolgingsoppgaverResponseDTO = OppfolgingsoppgaverResponseDTO(
 
 private fun generateOppfolgingsoppgave(
     oppfolgingsgrunn: String,
-): OppfolgingsoppgaveDTO = OppfolgingsoppgaveDTO(
+): OppfolgingsoppgaveNewDTO = OppfolgingsoppgaveNewDTO(
     uuid = UUID.randomUUID().toString(),
-    createdBy = VEILEDER_ID,
     updatedAt = LocalDateTime.now(),
     createdAt = LocalDateTime.now(),
-    tekst = "En tekst",
-    oppfolgingsgrunn = oppfolgingsgrunn,
-    frist = LocalDate.now().plusDays(14),
+    isActive = true,
+    personIdent = PersonIdent(ARBEIDSTAKER_FNR),
+    publishedAt = null,
+    removedBy = null,
+    versjoner = listOf(
+        OppfolgingoppgaveVersjonDTO(
+            uuid = UUID.randomUUID().toString(),
+            createdAt = LocalDateTime.now(),
+            createdBy = VEILEDER_ID,
+            tekst = "En tekst",
+            oppfolgingsgrunn = oppfolgingsgrunn,
+            frist = LocalDate.now().plusDays(14),
+        )
+    ),
 )

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/OppfolgingsoppgaveMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/OppfolgingsoppgaveMock.kt
@@ -15,7 +15,7 @@ import java.util.*
 fun MockRequestHandleScope.oppfolgingsoppgaveMockResponse(): HttpResponseData =
     respondOk(oppfolgingsoppgaverResponseDTO)
 
-private val oppfolgingsoppgaverResponseDTO = OppfolgingsoppgaverNewResponseDTO(
+private val oppfolgingsoppgaverResponseDTO = OppfolgingsoppgaverResponseDTO(
     oppfolgingsoppgaver = mapOf(
         ARBEIDSTAKER_FNR to generateOppfolgingsoppgave("FOLG_OPP_ETTER_NESTE_SYKMELDING"),
         ARBEIDSTAKER_2_FNR to generateOppfolgingsoppgave("VURDER_ANNEN_YTELSE"),
@@ -25,7 +25,7 @@ private val oppfolgingsoppgaverResponseDTO = OppfolgingsoppgaverNewResponseDTO(
 
 private fun generateOppfolgingsoppgave(
     oppfolgingsgrunn: String,
-): OppfolgingsoppgaveNewDTO = OppfolgingsoppgaveNewDTO(
+): OppfolgingsoppgaveDTO = OppfolgingsoppgaveDTO(
     uuid = UUID.randomUUID().toString(),
     updatedAt = LocalDateTime.now(),
     createdAt = LocalDateTime.now(),


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Tatt i bruk nytt endepunkt for å hente aktive oppfølgingsoppgaver som er implementert i følgende [PR](https://github.com/navikt/ishuskelapp/pull/85).

Jeg valgte å beholde de eksisterende typene for oppfølgingsoppgave, men at det gjøres en transformasjon fra ny datamodell til den som allerede eksisterer tidligst mulig (mao. etter kall på ws).
