### PR TITLE
IS-2460: Endret tilbake til det originale endepunktet siden disse er nå helt identiske og det midlertidige skal fjernes

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/oppfolgingsoppgave/OppfolgingsoppgaveClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/oppfolgingsoppgave/OppfolgingsoppgaveClient.kt
@@ -74,7 +74,7 @@ class OppfolgingsoppgaveClient(
     }
 
     companion object {
-        const val GET_OPPFOLGINGSOPPGAVER_API_PATH = "/api/internad/v1/huskelapp/get-oppfolgingsoppgaver-new"
+        const val GET_OPPFOLGINGSOPPGAVER_API_PATH = "/api/internad/v1/huskelapp/get-oppfolgingsoppgaver"
 
         private val log = LoggerFactory.getLogger(OppfolgingsoppgaveClient::class.java)
     }


### PR DESCRIPTION

### Hva har blitt lagt til✨🌈
Opprydding ifm. refaktorering av versjoner for oppfølgingsoppgave. Det ble endret i følgende PR: https://github.com/navikt/ishuskelapp/pull/86. Nåværende implementasjon av endepunktene `get-oppfolgingsoppgaver` og `get-oppfolgingsoppgaver-new` er nå helt identiske og dermed er det ikke lenger behov for å bruke det midlertidige endepunktet. Eksisterende implementasjon av begge finnes [her](https://github.com/navikt/ishuskelapp/blob/master/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsoppgaveApi.kt#L121-L183) (Det vil komme en siste PR som da sletter det ekstra endepunktet fra ishuskelapp)
