### PR TITLE
IS-2260: VeilederClient

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -59,6 +59,7 @@ spec:
         - application: istilgangskontroll
         - application: ishuskelapp
         - application: ismeroppfolging
+        - application: syfoveileder
   azure:
     application:
       allowAllUsers: true
@@ -96,6 +97,10 @@ spec:
       value: "dev-gcp.teamsykefravr.syfobehandlendeenhet"
     - name: SYFOBEHANDLENDEENHET_URL
       value: "http://syfobehandlendeenhet"
+    - name: SYFOVEILEDER_CLIENT_ID
+      value: "dev-gcp.teamsykefravr.syfoveileder"
+    - name: SYFOVEILEDER_URL
+      value: "http://syfoveileder"
     - name: ARBEIDSUFORHETVURDERING_CLIENT_ID
       value: "dev-gcp.teamsykefravr.isarbeidsuforhet"
     - name: ARBEIDSUFORHETVURDERING_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -60,6 +60,7 @@ spec:
         - application: istilgangskontroll
         - application: ishuskelapp
         - application: ismeroppfolging
+        - application: syfoveileder
   azure:
     application:
       allowAllUsers: true
@@ -97,6 +98,10 @@ spec:
       value: "prod-gcp.teamsykefravr.syfobehandlendeenhet"
     - name: SYFOBEHANDLENDEENHET_URL
       value: "http://syfobehandlendeenhet"
+    - name: SYFOVEILEDER_CLIENT_ID
+      value: "prod-gcp.teamsykefravr.syfoveileder"
+    - name: SYFOVEILEDER_URL
+      value: "http://syfoveileder"
     - name: ARBEIDSUFORHETVURDERING_CLIENT_ID
       value: "prod-gcp.teamsykefravr.isarbeidsuforhet"
     - name: ARBEIDSUFORHETVURDERING_URL

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -56,6 +56,10 @@ data class Environment(
             baseUrl = getEnvVar("SYFOBEHANDLENDEENHET_URL"),
             clientId = getEnvVar("SYFOBEHANDLENDEENHET_CLIENT_ID"),
         ),
+        syfoveileder = ClientEnvironment(
+            clientId = getEnvVar("SYFOVEILEDER_CLIENT_ID"),
+            baseUrl = getEnvVar("SYFOVEILEDER_URL"),
+        ),
         arbeidsuforhetvurdering = ClientEnvironment(
             baseUrl = getEnvVar("ARBEIDSUFORHETVURDERING_URL"),
             clientId = getEnvVar("ARBEIDSUFORHETVURDERING_CLIENT_ID"),

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/ClientEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/ClientEnvironment.kt
@@ -10,6 +10,7 @@ data class ClientsEnvironment(
     val istilgangskontroll: ClientEnvironment,
     val ishuskelapp: ClientEnvironment,
     val ismeroppfolging: ClientEnvironment,
+    val syfoveileder: ClientEnvironment,
 )
 
 data class ClientEnvironment(

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederClient.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederClient.kt
@@ -1,0 +1,80 @@
+package no.nav.syfo.personstatus.infrastructure.clients.veileder
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.micrometer.core.instrument.Counter
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.personstatus.infrastructure.clients.ClientEnvironment
+import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
+import no.nav.syfo.personstatus.infrastructure.clients.httpClientDefault
+import no.nav.syfo.personstatus.infrastructure.METRICS_NS
+import no.nav.syfo.personstatus.infrastructure.METRICS_REGISTRY
+import no.nav.syfo.util.*
+import org.slf4j.LoggerFactory
+
+class VeilederClient(
+    private val azureAdClient: AzureAdClient,
+    private val clientEnvironment: ClientEnvironment,
+    private val httpClient: HttpClient = httpClientDefault(),
+) {
+    private val veiledereUrl = "${clientEnvironment.baseUrl}$VEILEDERE_PATH"
+
+    suspend fun getVeileder(
+        callId: String,
+        veilederIdent: String,
+    ): Result<VeilederDTO?> {
+        val systemToken = azureAdClient.getSystemToken(
+            scopeClientId = clientEnvironment.clientId,
+        )?.accessToken ?: return Result.failure(RuntimeException("Failed to request access to veileder: Failed to get system token"))
+        return try {
+            val response: HttpResponse = httpClient.get("$veiledereUrl/$veilederIdent") {
+                header(HttpHeaders.Authorization, bearerHeader(systemToken))
+                header(NAV_CALL_ID_HEADER, callId)
+                accept(ContentType.Application.Json)
+            }
+            COUNT_CALL_SYFOVEILEDER_SUCCESS.increment()
+            Result.success(response.body())
+        } catch (e: ResponseException) {
+            if (e.response.status == HttpStatusCode.NotFound) {
+                log.warn("Veileder $veilederIdent not found in syfoveileder")
+                COUNT_CALL_SYFOVEILEDER_NOT_FOUND.increment()
+                Result.success(null)
+            } else {
+                log.error(
+                    "Error while requesting veileder from syfoveileder with {}, {}",
+                    StructuredArguments.keyValue("statusCode", e.response.status.value.toString()),
+                    callIdArgument(callId)
+                )
+                COUNT_CALL_SYFOVEILEDER_FAIL.increment()
+                Result.failure(e)
+            }
+        }
+    }
+
+    companion object {
+        const val VEILEDERE_PATH = "/syfoveileder/api/system/veiledere"
+        private val log = LoggerFactory.getLogger(this::class.java)
+
+        private const val CALL_SYFOVEILEDER_BASE = "${METRICS_NS}_call_syfoveileder"
+        private const val CALL_SYFOVEILEDER_SUCCESS = "${CALL_SYFOVEILEDER_BASE}_success_count"
+        private const val CALL_SYFOVEILEDER_NOT_FOUND = "${CALL_SYFOVEILEDER_BASE}_not_found_count"
+        private const val CALL_SYFOVEILEDER_FAIL = "${CALL_SYFOVEILEDER_BASE}_fail_count"
+
+        val COUNT_CALL_SYFOVEILEDER_SUCCESS: Counter = Counter
+            .builder(CALL_SYFOVEILEDER_SUCCESS)
+            .description("Counts the number of successful calls to syfoveileder")
+            .register(METRICS_REGISTRY)
+        val COUNT_CALL_SYFOVEILEDER_NOT_FOUND: Counter = Counter
+            .builder(CALL_SYFOVEILEDER_NOT_FOUND)
+            .description("Counts the number of calls to syfoveileder where veileder was not found")
+            .register(METRICS_REGISTRY)
+        val COUNT_CALL_SYFOVEILEDER_FAIL: Counter = Counter
+            .builder(CALL_SYFOVEILEDER_FAIL)
+            .description("Counts the number of failed calls to syfoveileder")
+            .register(METRICS_REGISTRY)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederDTO.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.personstatus.infrastructure.clients.veileder
+
+data class VeilederDTO(
+    val enabled: Boolean? = null,
+    val ident: String,
+)

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederClientSpek.kt
@@ -1,0 +1,59 @@
+package no.nav.syfo.personstatus.infrastructure.clients.veileder
+
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
+import no.nav.syfo.testutil.ExternalMockEnvironment
+import no.nav.syfo.testutil.UserConstants
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+private const val anyCallId = "callId"
+
+object VeilederClientSpek : Spek({
+    val externalMockEnvironment = ExternalMockEnvironment.instance
+    val azureAdClient = AzureAdClient(
+        azureEnvironment = externalMockEnvironment.environment.azure,
+        redisStore = externalMockEnvironment.redisStore,
+        httpClient = externalMockEnvironment.mockHttpClient
+    )
+    val veilederClient = VeilederClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = externalMockEnvironment.environment.clients.syfoveileder,
+        httpClient = externalMockEnvironment.mockHttpClient
+    )
+
+    describe("getVeileder") {
+        it("Returns veileder result when veileder found") {
+            val result = runBlocking {
+                veilederClient.getVeileder(
+                    callId = anyCallId,
+                    veilederIdent = UserConstants.VEILEDER_ID,
+                )
+            }
+
+            val veilederDTO = result.getOrThrow()
+            veilederDTO?.enabled shouldBeEqualTo true
+            veilederDTO?.ident shouldBeEqualTo UserConstants.VEILEDER_ID
+        }
+        it("Returns null result when veileder not found") {
+            val result = runBlocking {
+                veilederClient.getVeileder(
+                    callId = anyCallId,
+                    veilederIdent = UserConstants.VEILEDER_ID_2,
+                )
+            }
+            val veilederDTO = result.getOrThrow()
+            veilederDTO shouldBeEqualTo null
+        }
+        it("Returns failure when request fails") {
+            val result = runBlocking {
+                veilederClient.getVeileder(
+                    callId = anyCallId,
+                    veilederIdent = UserConstants.VEILEDER_ID_WITH_ERROR,
+                )
+            }
+            result.isFailure shouldBeEqualTo true
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -84,6 +84,10 @@ fun testEnvironment(
             baseUrl = "ismeroppfolgingUrl",
             clientId = "dev-gcp.teamsykefravr.ismeroppfolging",
         ),
+        syfoveileder = ClientEnvironment(
+            clientId = "dev-gcp.teamsykefravr.syfoveileder",
+            baseUrl = "syfoveilederUrl",
+        ),
     ),
     redisConfig = RedisConfig(
         redisUri = URI("http://localhost:6379"),

--- a/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
@@ -23,6 +23,7 @@ object UserConstants {
     const val NAV_ENHET_2 = "0331"
     const val VEILEDER_ID = "Z999999"
     const val VEILEDER_ID_2 = "Z999998"
+    const val VEILEDER_ID_WITH_ERROR = "Z999997"
     const val VEILEDER_IDENT_NO_AZURE_AD_TOKEN = "Z00000_no_azure_ad_token"
     const val VIRKSOMHETSNUMMER = "123456789"
     const val VIRKSOMHETSNUMMER_2 = "123456781"

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/MockHttpClient.kt
@@ -25,6 +25,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
                 requestUrl.startsWith("/${environment.clients.manglendeMedvirkning.baseUrl}") -> manglendeMedvirkningMockResponse()
                 requestUrl.startsWith("/${environment.clients.aktivitetskrav.baseUrl}") -> aktivitetskravMockResponse()
                 requestUrl.startsWith("/${environment.clients.ismeroppfolging.baseUrl}") -> merOppfolgingMockResponse()
+                requestUrl.startsWith("/${environment.clients.syfoveileder.baseUrl}") -> veilederMockResponse(request)
 
                 else -> error("Unhandled ${request.url.encodedPath}")
             }

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/SyfoveilederMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/SyfoveilederMock.kt
@@ -1,0 +1,20 @@
+package no.nav.syfo.testutil.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.personstatus.infrastructure.clients.veileder.VeilederDTO
+import no.nav.syfo.testutil.UserConstants
+
+fun MockRequestHandleScope.veilederMockResponse(requestData: HttpRequestData): HttpResponseData {
+    val requestUrl = requestData.url.encodedPath
+
+    return when {
+        requestUrl.endsWith(UserConstants.VEILEDER_ID) -> respondOk(
+            VeilederDTO(enabled = true, ident = UserConstants.VEILEDER_ID)
+        )
+        requestUrl.endsWith(UserConstants.VEILEDER_ID_2) -> respondError(status = HttpStatusCode.NotFound)
+        requestUrl.endsWith(UserConstants.VEILEDER_ID_WITH_ERROR) -> respondError(status = HttpStatusCode.InternalServerError)
+        else -> error("Unhandled path $requestUrl")
+    }
+}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Slik at vi kan sjekke om veilder har sluttet og fjerne veiledertildeling.
Laget client for å kalle endepunkt i syfoveileder for å sjekke om veileder finnes/er enabled. Se relatert PR i syfoveileder: https://github.com/navikt/syfoveileder/pull/121
Tenkte å fortsette med PR som tar i bruk clienten fra kode som konsumerer oppfølgingstilfeller.
