### PR TITLE
IS-2260: Check tildelt veileder when updating person oppfolgingstilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -21,6 +21,7 @@ import no.nav.syfo.personstatus.infrastructure.clients.oppfolgingsoppgave.Oppfol
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.personstatus.application.PersonBehandlendeEnhetService
+import no.nav.syfo.personstatus.infrastructure.clients.veileder.VeilederClient
 import no.nav.syfo.personstatus.infrastructure.cronjob.launchCronjobModule
 import no.nav.syfo.personstatus.infrastructure.database.database
 import no.nav.syfo.personstatus.infrastructure.database.databaseModule
@@ -96,6 +97,10 @@ fun main() {
         azureAdClient = azureAdClient,
         istilgangskontrollEnv = environment.clients.istilgangskontroll,
     )
+    val veilederClient = VeilederClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = environment.clients.syfoveileder,
+    )
 
     lateinit var personBehandlendeEnhetService: PersonBehandlendeEnhetService
     lateinit var personoversiktStatusService: PersonoversiktStatusService
@@ -125,6 +130,7 @@ fun main() {
             oppfolgingstilfelleService = OppfolgingstilfelleService(
                 pdlClient = pdlClient,
                 personOversiktStatusRepository = personoversiktStatusRepository,
+                veilederClient = veilederClient,
             )
             personoversiktStatusService = PersonoversiktStatusService(
                 database = database,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonMetric.kt
@@ -12,6 +12,8 @@ const val KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_SKIPPED_NO_TILFELLE =
     "${KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_BASE}_skipped_no_tilfelle"
 const val KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_NOT_ARBEIDSTAKER =
     "${KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_BASE}_skipped_not_arbeidstaker"
+const val KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_TILDELT_VEILEDER_NOT_FOUND_OR_NOT_ENABLED =
+    "${KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_BASE}_tildelt_veileder_not_found_or_not_enabled"
 
 val COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_READ: Counter = Counter.builder(KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_READ)
     .description("Counts the number of reads from topic - oppfolgingstilfelle-person")
@@ -29,3 +31,8 @@ val COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_NOT_ARBEIDSTAKER: Counter =
     Counter.builder(KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_NOT_ARBEIDSTAKER)
         .description("Counts the number of skipped from topic - oppfolgingstilfelle-person - Person is not arbeidstaker at end of latest Tilfelle")
         .register(METRICS_REGISTRY)
+
+val COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_TILDELT_VEILEDER_NOT_FOUND_OR_NOT_ENABLED: Counter = Counter.builder(
+    KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_TILDELT_VEILEDER_NOT_FOUND_OR_NOT_ENABLED
+).description("Counts the number of reads from topic - oppfolgingstilfelle-person - Person with tildelt veileder not found or not enabled")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/OppfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/OppfolgingstilfelleService.kt
@@ -41,9 +41,9 @@ class OppfolgingstilfelleService(
     private suspend fun createPersonWithNameAndFodselsdato(personStatus: PersonOversiktStatus) {
         pdlClient.getPerson(PersonIdent(personStatus.fnr))
             .map {
-                val editedPersonStatues =
+                val editedPersonStatus =
                     personStatus.updatePersonDetails(navn = it.fullName(), fodselsdato = it.fodselsdato())
-                personOversiktStatusRepository.createPersonOversiktStatus(editedPersonStatues)
+                personOversiktStatusRepository.createPersonOversiktStatus(editedPersonStatus)
             }.onFailure { throwable ->
                 log.error("Failed to get person from PDL: ${throwable.message}. Creating person without name and fodselsdato")
                 personOversiktStatusRepository.createPersonOversiktStatus(personStatus)

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/OppfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/OppfolgingstilfelleService.kt
@@ -79,7 +79,7 @@ class OppfolgingstilfelleService(
             veilederIdent = veilederIdent,
         ).fold(
             onSuccess = { veileder ->
-                if (veileder == null || veileder.enabled == false) {
+                if (veileder == null || !veileder.enabled) {
                     log.warn("Tildelt veileder $veilederIdent not found or not enabled")
                     COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_TILDELT_VEILEDER_NOT_FOUND_OR_NOT_ENABLED.increment()
                 }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/clients/veileder/VeilederDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.personstatus.infrastructure.clients.veileder
 
 data class VeilederDTO(
-    val enabled: Boolean? = null,
+    val enabled: Boolean,
     val ident: String,
 )

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.personstatus.application.OppfolgingstilfelleService
 import no.nav.syfo.personstatus.application.PersonoversiktStatusService
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
+import no.nav.syfo.personstatus.infrastructure.clients.veileder.VeilederClient
 import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository
 import no.nav.syfo.testutil.mock.*
 import redis.clients.jedis.DefaultJedisClientConfig
@@ -34,13 +35,19 @@ class ExternalMockEnvironment private constructor() {
 
     val personOversiktStatusRepository = PersonOversiktStatusRepository(database = database)
 
-    val pdlClient = PdlClient(
-        azureAdClient = AzureAdClient(
-            azureEnvironment = environment.azure,
-            redisStore = redisStore,
-            httpClient = mockHttpClient,
-        ),
+    private val azureAdClient = AzureAdClient(
+        azureEnvironment = environment.azure,
+        redisStore = redisStore,
+        httpClient = mockHttpClient,
+    )
+    private val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
         clientEnvironment = environment.clients.pdl,
+        httpClient = mockHttpClient
+    )
+    private val veilederClient = VeilederClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = environment.clients.syfoveileder,
         httpClient = mockHttpClient
     )
 
@@ -52,6 +59,7 @@ class ExternalMockEnvironment private constructor() {
     val oppfolgingstilfelleService = OppfolgingstilfelleService(
         pdlClient = pdlClient,
         personOversiktStatusRepository = personOversiktStatusRepository,
+        veilederClient = veilederClient
     )
 
     companion object {


### PR DESCRIPTION
Begynner med å logge og telle når vi konsumerer oppfølgingstilfelle for person og tildelt veileder ikke finnes eller ikke er enabled. Kommer ny PR som fjerner veileder-knytningen for disse tilfellene.
