### PR TITLE
IS-2260: Remove tildelt veileder if not found or enabled when updating oppfølgingstilfelle

### DIFF
--- a/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
@@ -23,6 +23,7 @@ object UserConstants {
     const val NAV_ENHET_2 = "0331"
     const val VEILEDER_ID = "Z999999"
     const val VEILEDER_ID_2 = "Z999998"
+    const val VEILEDER_ID_NOT_ENABLED = "Z999996"
     const val VEILEDER_ID_WITH_ERROR = "Z999997"
     const val VEILEDER_IDENT_NO_AZURE_AD_TOKEN = "Z00000_no_azure_ad_token"
     const val VIRKSOMHETSNUMMER = "123456789"

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/SyfoveilederMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/SyfoveilederMock.kt
@@ -13,6 +13,9 @@ fun MockRequestHandleScope.veilederMockResponse(requestData: HttpRequestData): H
         requestUrl.endsWith(UserConstants.VEILEDER_ID) -> respondOk(
             VeilederDTO(enabled = true, ident = UserConstants.VEILEDER_ID)
         )
+        requestUrl.endsWith(UserConstants.VEILEDER_ID_NOT_ENABLED) -> respondOk(
+            VeilederDTO(enabled = false, ident = UserConstants.VEILEDER_ID_NOT_ENABLED)
+        )
         requestUrl.endsWith(UserConstants.VEILEDER_ID_2) -> respondError(status = HttpStatusCode.NotFound)
         requestUrl.endsWith(UserConstants.VEILEDER_ID_WITH_ERROR) -> respondError(status = HttpStatusCode.InternalServerError)
         else -> error("Unhandled path $requestUrl")


### PR DESCRIPTION
Gjør sjekk på en persons tildelte veileder når det kommer inn oppdateringer på oppfølgingstilfelle.
Dersom veileder ikke finnes eller ikke er enabled fjerner vi tildelingen slik at person ikke er tildelt veileder som har sluttet når det kommer ny oppgaver/hendelser på personen.
