### PR TITLE
IS-1801: Add innstilling om stans status to dto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/aktivitetskrav/AktivitetskravDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/aktivitetskrav/AktivitetskravDTO.kt
@@ -23,7 +23,7 @@ data class AktivitetskravvurderingDTO(
     val status: AktivitetskravStatus,
     val frist: LocalDate?,
     val varsel: AktivitetskravVarselDTO?,
-    val arsaker: List<Arsak>
+    val arsaker: List<Arsak>,
 )
 
 data class AktivitetskravVarselDTO(
@@ -39,7 +39,7 @@ enum class AktivitetskravStatus {
     OPPFYLT,
     AUTOMATISK_OPPFYLT,
     FORHANDSVARSEL,
-    STANS,
+    INNSTILLING_OM_STANS,
     IKKE_OPPFYLT,
     IKKE_AKTUELL,
     LUKKET,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til `INNSTILLING_OM_STANS` til aktivitetskrav statuser.

- [x] Dobbeltsjekk at vi ikke har brukt `STANS` statusen noe sted i produksjon
