### PR TITLE
IS-2892: Get OppfolgingstilfelleVirksomhet for search result persons

### DIFF
--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -8,7 +8,6 @@ import io.mockk.clearMocks
 import io.mockk.every
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.dialogmotestatusendring.domain.DialogmoteStatusendringType
-import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
 import no.nav.syfo.personoppgavehendelse.kafka.KPersonoppgavehendelse
 import no.nav.syfo.personstatus.api.v2.endpoints.personOversiktApiV2Path
 import no.nav.syfo.personstatus.api.v2.model.PersonOversiktStatusDTO
@@ -752,18 +751,14 @@ object PersonoversiktStatusApiV2Spek : Spek({
                 testApplication {
                     val client = setupApiAndClient()
                     val virksomhetList = listOf(
-                        PersonOppfolgingstilfelleVirksomhet(
-                            uuid = UUID.randomUUID(),
-                            createdAt = OffsetDateTime.now(),
+                        generateOppfolgingstilfelleVirksomhet(
                             virksomhetsnummer = Virksomhetsnummer("123456789"),
                             virksomhetsnavn = "Virksomhet AS",
                         ),
-                        PersonOppfolgingstilfelleVirksomhet(
-                            uuid = UUID.randomUUID(),
-                            createdAt = OffsetDateTime.now(),
+                        generateOppfolgingstilfelleVirksomhet(
                             virksomhetsnummer = Virksomhetsnummer("123456000"),
                             virksomhetsnavn = null,
-                        )
+                        ),
                     )
                     val oppfolgingstilfelle = generateOppfolgingstilfelle(
                         start = LocalDate.now().minusDays(30),

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/OppfolgingstilfelleGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/OppfolgingstilfelleGenerator.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.testutil.generator
 
 import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
 import no.nav.syfo.oppfolgingstilfelle.domain.PersonOppfolgingstilfelleVirksomhet
+import no.nav.syfo.personstatus.domain.Virksomhetsnummer
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -20,4 +21,11 @@ fun generateOppfolgingstilfelle(
     oppfolgingstilfelleBitReferanseInntruffet = OffsetDateTime.now(),
     oppfolgingstilfelleBitReferanseUuid = UUID.randomUUID(),
     virksomhetList = virksomhetList,
+)
+
+fun generateOppfolgingstilfelleVirksomhet(virksomhetsnummer: Virksomhetsnummer, virksomhetsnavn: String?) = PersonOppfolgingstilfelleVirksomhet(
+    uuid = UUID.randomUUID(),
+    createdAt = OffsetDateTime.now(),
+    virksomhetsnummer = virksomhetsnummer,
+    virksomhetsnavn = virksomhetsnavn,
 )


### PR DESCRIPTION
For å kunne vise kolonne for Virksomhet i søkeresultatet må vi hente virksomhetsnummer og -navn fra egen databasetabell for alle personer i søkeresultatet og legge det til `personOppfolgingstilfelleVirksomhetList` i domeneobjektet slik at det blir med ut i dtoen fra APIet.