### PR TITLE
IS-3142: Add consumer for updating oppfolgingsenhet changes

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -30,7 +30,7 @@ interface IPersonOversiktStatusRepository {
 
     fun getVeilederTilknytningHistorikk(personident: PersonIdent): List<VeilederTildelingHistorikkDTO>
 
-    fun getPersonerWithOppgaveAndOldEnhet(): List<Pair<PersonIdent, String?>>
+    fun getPersonerWithOppgaveAndOldEnhet(): List<PersonIdent>
 
     fun getPersonerWithVeilederTildelingAndOldOppfolgingstilfelle(): List<PersonOversiktStatus>
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/PersonBehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/PersonBehandlendeEnhetService.kt
@@ -8,21 +8,21 @@ class PersonBehandlendeEnhetService(
     private val personoversiktStatusRepository: IPersonOversiktStatusRepository,
     private val behandlendeEnhetClient: BehandlendeEnhetClient,
 ) {
-    fun getPersonerToCheckForUpdatedEnhet(): List<Pair<PersonIdent, String?>> =
+    fun getPersonerToCheckForUpdatedEnhet(): List<PersonIdent> =
         personoversiktStatusRepository.getPersonerWithOppgaveAndOldEnhet()
 
-    suspend fun updateBehandlendeEnhet(
-        personIdent: PersonIdent,
-        tildeltEnhet: String? = null,
-    ) {
-        val maybeNewBehandlendeEnhet = behandlendeEnhetClient.getEnhet(
+    suspend fun updateBehandlendeEnhet(personIdent: PersonIdent) {
+        val behandlendeEnhet = behandlendeEnhetClient.getEnhet(
             callId = UUID.randomUUID().toString(),
             personIdent = personIdent,
         )
-        if (maybeNewBehandlendeEnhet != null && maybeNewBehandlendeEnhet.enhetId != tildeltEnhet) {
+        val tildeltEnhet = personoversiktStatusRepository.getPersonOversiktStatus(personIdent)?.enhet
+        val isEnhetUpdate = behandlendeEnhet != null && behandlendeEnhet.enhetId != tildeltEnhet
+
+        if (isEnhetUpdate) {
             personoversiktStatusRepository.updatePersonTildeltEnhetAndRemoveTildeltVeileder(
                 personIdent = personIdent,
-                enhetId = maybeNewBehandlendeEnhet.enhetId,
+                enhetId = behandlendeEnhet.enhetId,
             )
         } else {
             personoversiktStatusRepository.updatePersonTildeltEnhetUpdatedAt(

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/oppfolgingsoppgave/OppfolgingsoppgaveService.kt
@@ -14,7 +14,6 @@ import no.nav.syfo.personstatus.infrastructure.database.queries.updateOppfolging
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.collections.filter
-import kotlin.collections.first
 import kotlin.collections.firstOrNull
 import kotlin.collections.forEach
 import kotlin.jvm.java
@@ -27,10 +26,7 @@ class OppfolgingsoppgaveService(
     fun processOppfolgingsoppgave(records: List<OppfolgingsoppgaveRecord>) {
         createOrUpdatePersonOversiktStatus(records)
         records.filter { it.isActive }.forEach {
-            val personOversiktStatus = database.getPersonOversiktStatusList(
-                fnr = it.personIdent,
-            ).first()
-            updateBehandlendeEnhet(PersonIdent(it.personIdent), personOversiktStatus.enhet)
+            updateBehandlendeEnhet(PersonIdent(it.personIdent))
         }
     }
 
@@ -61,17 +57,11 @@ class OppfolgingsoppgaveService(
         }
     }
 
-    private fun updateBehandlendeEnhet(
-        personIdent: PersonIdent,
-        existingEnhet: String?,
-    ) {
+    private fun updateBehandlendeEnhet(personIdent: PersonIdent) {
         try {
             runBlocking {
                 launch(Dispatchers.IO) {
-                    personBehandlendeEnhetService.updateBehandlendeEnhet(
-                        personIdent = personIdent,
-                        tildeltEnhet = existingEnhet
-                    )
+                    personBehandlendeEnhetService.updateBehandlendeEnhet(personIdent = personIdent)
                     log.info("Updated Behandlende Enhet of person after received active oppfolgingsoppgave")
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjob.kt
@@ -22,13 +22,9 @@ class PersonBehandlendeEnhetCronjob(
         val result = CronjobResult()
 
         personBehandlendeEnhetService.getPersonerToCheckForUpdatedEnhet()
-            .forEach { personIdentTildeltEnhetPair ->
+            .forEach { personident ->
                 try {
-                    val (personIdent, tildeltEnhet) = personIdentTildeltEnhetPair
-                    personBehandlendeEnhetService.updateBehandlendeEnhet(
-                        personIdent = personIdent,
-                        tildeltEnhet = tildeltEnhet,
-                    )
+                    personBehandlendeEnhetService.updateBehandlendeEnhet(personIdent = personident)
                     result.updated++
                     COUNT_CRONJOB_PERSON_BEHANDLENDE_ENHET_UPDATE.increment()
                 } catch (ex: Exception) {

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -237,15 +237,10 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
             }
         }
 
-    override fun getPersonerWithOppgaveAndOldEnhet(): List<Pair<PersonIdent, String?>> =
+    override fun getPersonerWithOppgaveAndOldEnhet(): List<PersonIdent> =
         database.connection.use { connection ->
             connection.prepareStatement(GET_PERSONER_WITH_OPPGAVE_AND_OLD_ENHET).use {
-                it.executeQuery().toList {
-                    Pair(
-                        PersonIdent(getString("fnr")),
-                        getString("tildelt_enhet"),
-                    )
-                }
+                it.executeQuery().toList { PersonIdent(getString("fnr")) }
             }
         }
 
@@ -334,7 +329,8 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         }
 
         return results.map {
-            val personOppfolgingstilfelleVirksomhetList = personOppfolgingstilfelleVirksomhetMap[it.id]?.toPersonOppfolgingstilfelleVirksomhet() ?: emptyList()
+            val personOppfolgingstilfelleVirksomhetList =
+                personOppfolgingstilfelleVirksomhetMap[it.id]?.toPersonOppfolgingstilfelleVirksomhet() ?: emptyList()
             it.toPersonOversiktStatus(personOppfolgingstilfelleVirksomhetList = personOppfolgingstilfelleVirksomhetList)
         }
     }
@@ -537,7 +533,7 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
 
         private const val GET_PERSONER_WITH_OPPGAVE_AND_OLD_ENHET =
             """
-            SELECT fnr, tildelt_enhet
+            SELECT fnr
             FROM PERSON_OVERSIKT_STATUS
             WHERE $AKTIV_OPPGAVE_WHERE_CLAUSE    
             AND (tildelt_enhet_updated_at IS NULL OR tildelt_enhet_updated_at <= NOW() - INTERVAL '24 HOURS')

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaModule.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.pdlpersonhendelse.kafka.launchKafkaTaskPersonhendelse
 import no.nav.syfo.personoppgavehendelse.kafka.launchKafkaTaskPersonoppgavehendelse
 import no.nav.syfo.personstatus.application.PersonoversiktStatusService
 import no.nav.syfo.personstatus.application.OppfolgingstilfelleService
+import no.nav.syfo.personstatus.infrastructure.kafka.behandlendeenhet.BehandlendeEnhetConsumer
 import no.nav.syfo.personstatus.infrastructure.kafka.manglendemedvirkning.ManglendeMedvirkningVurderingConsumer
 import no.nav.syfo.personstatus.infrastructure.kafka.meroppfolging.SenOppfolgingKandidatStatusConsumer
 import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsoppgave.launchOppfolgingsoppgaveConsumer
@@ -81,6 +82,12 @@ fun launchKafkaModule(
         )
 
     ManglendeMedvirkningVurderingConsumer(personoversiktStatusService = personoversiktStatusService)
+        .start(
+            applicationState = applicationState,
+            kafkaEnvironment = environment.kafka,
+        )
+
+    BehandlendeEnhetConsumer(personBehandlendeEnhetService = personBehandlendeEnhetService)
         .start(
             applicationState = applicationState,
             kafkaEnvironment = environment.kafka,

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/behandlendeenhet/BehandlendeEnhetConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/behandlendeenhet/BehandlendeEnhetConsumer.kt
@@ -1,0 +1,77 @@
+package no.nav.syfo.personstatus.infrastructure.kafka.behandlendeenhet
+
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.personstatus.application.PersonBehandlendeEnhetService
+import no.nav.syfo.personstatus.domain.PersonIdent
+import no.nav.syfo.personstatus.infrastructure.kafka.KafkaConsumerService
+import no.nav.syfo.personstatus.infrastructure.kafka.KafkaEnvironment
+import no.nav.syfo.personstatus.infrastructure.kafka.kafkaAivenConsumerConfig
+import no.nav.syfo.personstatus.infrastructure.kafka.launchKafkaTask
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.Deserializer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.Properties
+
+class BehandlendeEnhetConsumer(
+    private val personBehandlendeEnhetService: PersonBehandlendeEnhetService,
+) : KafkaConsumerService<BehandlendeEnhetUpdateRecord> {
+
+    override val pollDurationInMillis: Long = 1000
+
+    override suspend fun pollAndProcessRecords(consumer: KafkaConsumer<String, BehandlendeEnhetUpdateRecord>) {
+        val records = consumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            log.info("BehandlendeEnhetConsumer trace: Received ${records.count()} records")
+            processRecords(records = records)
+            consumer.commitSync()
+        }
+    }
+
+    private suspend fun processRecords(records: ConsumerRecords<String, BehandlendeEnhetUpdateRecord>) {
+        val (tombstoneRecords, validRecords) = records.partition { it.value() == null }
+        if (tombstoneRecords.isNotEmpty()) {
+            val numberOfTombstones = tombstoneRecords.size
+            log.error("Value of $numberOfTombstones ConsumerRecord are null, most probably due to a tombstone. Contact the owner of the topic if an error is suspected")
+        }
+        validRecords.map { record ->
+            personBehandlendeEnhetService.updateBehandlendeEnhet(
+                PersonIdent(record.value().personident)
+            )
+        }
+    }
+
+    fun start(applicationState: ApplicationState, kafkaEnvironment: KafkaEnvironment) {
+        val consumerProperties = Properties().apply {
+            putAll(kafkaAivenConsumerConfig(kafkaEnvironment = kafkaEnvironment))
+            this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = BehandlendeEnhetUpdateRecordDeserializer::class.java.canonicalName
+            this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+        }
+        launchKafkaTask(
+            applicationState = applicationState,
+            kafkaConsumerService = this,
+            consumerProperties = consumerProperties,
+            topic = TOPIC,
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java)
+        private const val TOPIC = "teamsykefravr.behandlendeenhet"
+    }
+}
+
+data class BehandlendeEnhetUpdateRecord(
+    val personident: String,
+    val updatedAt: OffsetDateTime,
+)
+
+class BehandlendeEnhetUpdateRecordDeserializer : Deserializer<BehandlendeEnhetUpdateRecord> {
+    private val mapper = configuredJacksonMapper()
+    override fun deserialize(topic: String, data: ByteArray): BehandlendeEnhetUpdateRecord =
+        mapper.readValue(data, BehandlendeEnhetUpdateRecord::class.java)
+}

--- a/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/behandlendeenhet/PersonBehandlendeEnhetCronjobSpek.kt
@@ -93,7 +93,7 @@ object PersonBehandlendeEnhetCronjobSpek : Spek({
                     val pPersonOversiktStatus = pPersonOversiktStatusList.first()
 
                     pPersonOversiktStatus.enhet shouldNotBeEqualTo firstEnhet
-                    pPersonOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    pPersonOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     pPersonOversiktStatus.tildeltEnhetUpdatedAt.shouldNotBeNull()
                     pPersonOversiktStatus.tildeltEnhetUpdatedAt!!.toInstant()
                         .toEpochMilli() shouldBeGreaterThan tildeltEnhetUpdatedAtBeforeUpdate.toInstant()
@@ -171,7 +171,7 @@ object PersonBehandlendeEnhetCronjobSpek : Spek({
 
                     val pPersonOversiktStatus = pPersonOversiktStatusList.first()
 
-                    pPersonOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    pPersonOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     pPersonOversiktStatus.tildeltEnhetUpdatedAt.shouldNotBeNull()
                     pPersonOversiktStatus.tildeltEnhetUpdatedAt shouldNotBeEqualTo tildeltEnhetUpdatedAtBeforeUpdate
                     pPersonOversiktStatus.veilederIdent.shouldBeNull()

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/BehandlerdialogPersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/BehandlerdialogPersonoversiktStatusApiV2Spek.kt
@@ -58,7 +58,7 @@ object BehandlerdialogPersonoversiktStatusApiV2Spek : Spek({
                 response.status shouldBeEqualTo HttpStatusCode.OK
                 val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                 personOversiktStatus.fnr shouldBeEqualTo oversikthendelseBehandlerdialogSvarMottatt.personident
-                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                 personOversiktStatus.behandlerdialogUbehandlet shouldBeEqualTo true
             }
         }
@@ -87,7 +87,7 @@ object BehandlerdialogPersonoversiktStatusApiV2Spek : Spek({
 
                 val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                 personOversiktStatus.fnr shouldBeEqualTo oversikthendelseBehandlerdialogUbesvartMottatt.personident
-                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                 personOversiktStatus.behandlerdialogUbehandlet shouldBeEqualTo true
             }
         }
@@ -122,7 +122,7 @@ object BehandlerdialogPersonoversiktStatusApiV2Spek : Spek({
 
                 val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                 personOversiktStatus.fnr shouldBeEqualTo oversikthendelseBehandlerdialogSvarMottatt.personident
-                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                 personOversiktStatus.behandlerdialogUbehandlet shouldBeEqualTo true
             }
         }
@@ -151,7 +151,7 @@ object BehandlerdialogPersonoversiktStatusApiV2Spek : Spek({
 
                 val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                 personOversiktStatus.fnr shouldBeEqualTo oversikthendelseBehandlerdialogAvvistMottatt.personident
-                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                 personOversiktStatus.behandlerdialogUbehandlet shouldBeEqualTo true
             }
         }

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/DialogmotekandidatPersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/DialogmotekandidatPersonoversiktStatusApiV2Spek.kt
@@ -88,7 +88,7 @@ object DialogmotekandidatPersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.shouldNotBeNull()
                     personOversiktStatus.veilederIdent shouldBeEqualTo null
                     personOversiktStatus.fnr shouldBeEqualTo ARBEIDSTAKER_FNR
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet.shouldBeNull()
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet.shouldBeNull()
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false
@@ -112,7 +112,7 @@ object DialogmotekandidatPersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.shouldNotBeNull()
                     personOversiktStatus.veilederIdent shouldBeEqualTo null
                     personOversiktStatus.fnr shouldBeEqualTo ARBEIDSTAKER_FNR
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet.shouldBeNull()
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet.shouldBeNull()
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false

--- a/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/api/v2/PersonoversiktStatusApiV2Spek.kt
@@ -280,7 +280,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     }
                     personOversiktStatus.veilederIdent shouldBeEqualTo null
                     personOversiktStatus.fnr shouldBeEqualTo ARBEIDSTAKER_FNR
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet shouldBeEqualTo true
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldBeEqualTo true
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo true
@@ -325,7 +325,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.veilederIdent shouldBeEqualTo null
                     personOversiktStatus.fnr shouldBeEqualTo oversiktHendelse.personident
                     personOversiktStatus.navn shouldBeEqualTo getIdentName()
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet shouldBeEqualTo true
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldBeEqualTo null
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false
@@ -374,7 +374,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.veilederIdent shouldBeEqualTo tilknytning.veilederIdent
                     personOversiktStatus.fnr shouldBeEqualTo oversiktHendelse.personident
                     personOversiktStatus.navn shouldBeEqualTo getIdentName()
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet shouldBeEqualTo true
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldBeEqualTo true
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false
@@ -427,7 +427,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.veilederIdent shouldBeEqualTo tilknytning.veilederIdent
                     personOversiktStatus.fnr shouldBeEqualTo oversiktHendelse.personident
                     personOversiktStatus.navn shouldBeEqualTo getIdentName()
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet shouldBeEqualTo true
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldBeEqualTo true
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false
@@ -465,7 +465,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.veilederIdent shouldBeEqualTo null
                     personOversiktStatus.fnr shouldBeEqualTo oversiktHendelseOPLPSBistandMottatt.personident
                     personOversiktStatus.navn shouldBeEqualTo getIdentName()
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet shouldBeEqualTo null
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldBeEqualTo true
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false
@@ -499,7 +499,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     personOversiktStatus.veilederIdent shouldBeEqualTo null
                     personOversiktStatus.fnr shouldBeEqualTo oversiktHendelseOPLPSBistandMottatt.personident
                     personOversiktStatus.navn shouldBeEqualTo ""
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.motebehovUbehandlet shouldBeEqualTo null
                     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet shouldBeEqualTo true
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo false
@@ -558,7 +558,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                     personOversiktStatus.fnr shouldBeEqualTo oversikthendelseDialogmotesvarMottatt.personident
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.dialogmotesvarUbehandlet shouldBeEqualTo true
                 }
             }
@@ -578,7 +578,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                     personOversiktStatus.fnr shouldBeEqualTo personident.value
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo tomorrow
                 }
             }
@@ -598,7 +598,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                     personOversiktStatus.fnr shouldBeEqualTo personident.value
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo today
                 }
             }
@@ -618,7 +618,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                     personOversiktStatus.fnr shouldBeEqualTo personident.value
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.friskmeldingTilArbeidsformidlingFom!! shouldBeEqualTo yesterday
                 }
             }
@@ -643,7 +643,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                     personOversiktStatus.fnr shouldBeEqualTo personident
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.oppfolgingsoppgave shouldNotBe null
                     personOversiktStatus.oppfolgingsoppgave?.oppfolgingsgrunn shouldBeEqualTo "FOLG_OPP_ETTER_NESTE_SYKMELDING"
                     personOversiktStatus.oppfolgingsoppgave?.tekst shouldBeEqualTo "En tekst"
@@ -691,7 +691,7 @@ object PersonoversiktStatusApiV2Spek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val personOversiktStatus = response.body<List<PersonOversiktStatusDTO>>().first()
                     personOversiktStatus.fnr shouldBeEqualTo ARBEIDSTAKER_FNR
-                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO().enhetId
+                    personOversiktStatus.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
                     personOversiktStatus.behandlerBerOmBistandUbehandlet shouldBeEqualTo true
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/personstatus/application/PersonBehandlendeEnhetServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/application/PersonBehandlendeEnhetServiceSpek.kt
@@ -1,0 +1,56 @@
+package no.nav.syfo.personstatus.application
+
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.personstatus.domain.PersonIdent
+import no.nav.syfo.personstatus.domain.PersonOversiktStatus
+import no.nav.syfo.testutil.ExternalMockEnvironment
+import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
+import no.nav.syfo.testutil.dropData
+import org.amshove.kluent.shouldNotBe
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import no.nav.syfo.testutil.mock.behandlendeEnhetDTO
+import org.amshove.kluent.*
+
+class PersonBehandlendeEnhetServiceSpek : Spek({
+
+    describe(PersonBehandlendeEnhetService::class.java.simpleName) {
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+        val personBehandlendeEnhetService = externalMockEnvironment.personBehandlendeEnhetService
+        val personOversiktStatusRepository = externalMockEnvironment.personOversiktStatusRepository
+
+        beforeEachTest { database.dropData() }
+        afterEachGroup { database.dropData() }
+
+        describe("updateBehandlendeEnhet") {
+            it("correctly updates enhet when no enhet assigned") {
+                personOversiktStatusRepository.createPersonOversiktStatus(
+                    PersonOversiktStatus(fnr = ARBEIDSTAKER_FNR, enhet = null)
+                )
+
+                runBlocking {
+                    personBehandlendeEnhetService.updateBehandlendeEnhet(personIdent = PersonIdent(ARBEIDSTAKER_FNR))
+                }
+
+                val personOversiktStatus = personOversiktStatusRepository.getPersonOversiktStatus(PersonIdent(ARBEIDSTAKER_FNR))
+                personOversiktStatus shouldNotBe null
+                personOversiktStatus!!.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
+            }
+
+            it("correctly updates enhet when other enhet is already assigned") {
+                personOversiktStatusRepository.createPersonOversiktStatus(
+                    PersonOversiktStatus(fnr = ARBEIDSTAKER_FNR, enhet = "0314")
+                )
+
+                runBlocking {
+                    personBehandlendeEnhetService.updateBehandlendeEnhet(personIdent = PersonIdent(ARBEIDSTAKER_FNR))
+                }
+
+                val personOversiktStatus = personOversiktStatusRepository.getPersonOversiktStatus(PersonIdent(ARBEIDSTAKER_FNR))
+                personOversiktStatus shouldNotBe null
+                personOversiktStatus!!.enhet shouldBeEqualTo behandlendeEnhetDTO.enhetId
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -3,8 +3,10 @@ package no.nav.syfo.testutil
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.application.cache.ValkeyStore
 import no.nav.syfo.personstatus.application.OppfolgingstilfelleService
+import no.nav.syfo.personstatus.application.PersonBehandlendeEnhetService
 import no.nav.syfo.personstatus.application.PersonoversiktStatusService
 import no.nav.syfo.personstatus.infrastructure.clients.azuread.AzureAdClient
+import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.personstatus.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.personstatus.infrastructure.clients.veileder.VeilederClient
 import no.nav.syfo.personstatus.infrastructure.database.repository.PersonOversiktStatusRepository
@@ -55,6 +57,14 @@ class ExternalMockEnvironment private constructor() {
         database = database,
         pdlClient = pdlClient,
         personoversiktStatusRepository = personOversiktStatusRepository,
+    )
+    val personBehandlendeEnhetService = PersonBehandlendeEnhetService(
+        personoversiktStatusRepository = personOversiktStatusRepository,
+        behandlendeEnhetClient = BehandlendeEnhetClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = environment.clients.syfobehandlendeenhet,
+            httpClient = mockHttpClient
+        )
     )
     val oppfolgingstilfelleService = OppfolgingstilfelleService(
         pdlClient = pdlClient,

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/SyfobehandlendeenhetMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/SyfobehandlendeenhetMock.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.Behandle
 import no.nav.syfo.testutil.UserConstants
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 
-fun behandlendeEnhetDTO() =
+val behandlendeEnhetDTO =
     BehandlendeEnhetDTO(
         enhetId = UserConstants.NAV_ENHET,
         navn = "Navkontor",
@@ -25,7 +25,7 @@ fun MockRequestHandleScope.getBehandlendeEnhetResponse(request: HttpRequestData)
             )
         }
         else -> {
-            respondOk(behandlendeEnhetDTO())
+            respondOk(behandlendeEnhetDTO)
         }
     }
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til kafka consumer som lytter på `teamsykefravr.behandlendeenhet` topicet som det blir produsert til når oppfølgingsenhet blir endret i `syfobehandlendeenhet`.

Se [tilhørende PR](https://github.com/navikt/syfobehandlendeenhet/pull/172) i `syfobehandlendeenhet`
