### PR TITLE
Oppfolgingsenhet nulling

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/CronjobModule.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.personstatus.infrastructure.clients.ereg.EregClient
 import no.nav.syfo.personstatus.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.personstatus.infrastructure.cronjob.behandlendeenhet.PersonBehandlendeEnhetCronjob
 import no.nav.syfo.personstatus.application.PersonBehandlendeEnhetService
+import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.personstatus.infrastructure.cronjob.leaderelection.LeaderPodClient
 import no.nav.syfo.personstatus.infrastructure.cronjob.preloadcache.PreloadCacheCronjob
 import no.nav.syfo.personstatus.infrastructure.cronjob.reaper.ReaperCronjob
@@ -29,6 +30,10 @@ fun launchCronjobModule(
     val eregClient = EregClient(
         clientEnvironment = environment.clients.ereg,
         valkeyStore = valkeyStore,
+    )
+    val behandlendeEnhetClient = BehandlendeEnhetClient(
+        azureAdClient = azureAdClient,
+        clientEnvironment = environment.clients.syfobehandlendeenhet,
     )
     val personOppfolgingstilfelleVirksomhetsnavnService = PersonOppfolgingstilfelleVirksomhetsnavnService(
         database = database,
@@ -49,6 +54,7 @@ fun launchCronjobModule(
 
     val reaperCronjob = ReaperCronjob(
         personOversiktStatusService = personoversiktStatusService,
+        behandlendeEnhetClient = behandlendeEnhetClient,
     )
 
     val tilgangskontrollClient = VeilederTilgangskontrollClient(

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/reaper/ReaperCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/reaper/ReaperCronjob.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.personstatus.infrastructure.cronjob.reaper
 
-import kotlinx.coroutines.runBlocking
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.personstatus.application.PersonoversiktStatusService
 import no.nav.syfo.personstatus.domain.PersonIdent
@@ -9,7 +8,6 @@ import no.nav.syfo.personstatus.infrastructure.cronjob.Cronjob
 import no.nav.syfo.personstatus.infrastructure.cronjob.CronjobResult
 import org.slf4j.LoggerFactory
 import java.util.*
-
 
 /**
 * Formålet med denne cronjob'en er å nulle ut veilederknytning for personer som ikke lengre er under

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/reaper/ReaperCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/reaper/ReaperCronjob.kt
@@ -10,6 +10,16 @@ import no.nav.syfo.personstatus.infrastructure.cronjob.CronjobResult
 import org.slf4j.LoggerFactory
 import java.util.*
 
+
+/**
+* Formålet med denne cronjob'en er å nulle ut veilederknytning for personer som ikke lengre er under
+* oppfølging. Problemet som løses er at vi ikke ønsker at personer som blir syke på nytt tar med seg
+* en veilederknytning fra et tidligere oppfølgingstilfelle (veilederen kan ha sluttet eller flyttet
+* til en annen enhet, eller personen kan ha flyttet i mellomtiden).
+* *Desember 2024:* Endrer slik at veilederknytningen nulles når det har gått 2 måneder (fra 3) siden siste
+* oppfølgingstilfelle-end og minst 2 måneder siden siste oppdatering.
+* *Mars 2025:* Utvider til også å nulle oppfølgingsenhet
+*/
 class ReaperCronjob(
     private val personOversiktStatusService: PersonoversiktStatusService,
     private val behandlendeEnhetClient: BehandlendeEnhetClient,
@@ -23,29 +33,18 @@ class ReaperCronjob(
         runJob()
     }
 
-    fun runJob(): CronjobResult {
+    suspend fun runJob(): CronjobResult {
         log.info("Run ReaperCronjob")
         val result = CronjobResult()
 
-        /*
-        Formålet med denne cronjob'en er å nulle ut veilederknytning for personer som ikke lengre er under
-        oppfølging. Problemet som løses er at vi ikke ønsker at personer som blir syke på nytt tar med seg
-        en veilederknytning fra et tidligere oppfølgingstilfelle (veilederen kan ha sluttet eller flyttet
-        til en annen enhet, eller personen kan ha flyttet i mellomtiden).
-        Desember 2024: Endrer slik at veilederknytningen nulles når det har gått 2 måneder (fra 3) siden siste
-        oppfølgingstilfelle-end og minst 2 måneder siden siste oppdatering.
-        Mars 2025: Utvider til også å nulle oppfølgingsenhet
-         */
         personOversiktStatusService.getPersonerWithVeilederTildelingAndOldOppfolgingstilfelle()
             .forEach {
                 try {
                     personOversiktStatusService.removeTildeltVeileder(PersonIdent(it.fnr))
-                    runBlocking {
-                        behandlendeEnhetClient.unsetOppfolgingsenhet(
-                            callId = UUID.randomUUID().toString(),
-                            personIdent = PersonIdent(it.fnr),
-                        )
-                    }
+                    behandlendeEnhetClient.unsetOppfolgingsenhet(
+                        callId = UUID.randomUUID().toString(),
+                        personIdent = PersonIdent(it.fnr),
+                    )
                     result.updated++
                     COUNT_CRONJOB_REAPER_UPDATE.increment()
                 } catch (ex: Exception) {

--- a/src/test/kotlin/no/nav/syfo/cronjob/reaper/ReaperCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/reaper/ReaperCronjobSpek.kt
@@ -1,8 +1,13 @@
 package no.nav.syfo.cronjob.reaper
 
+import io.mockk.clearMocks
+import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.personstatus.domain.PersonIdent
 import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import no.nav.syfo.personstatus.domain.toPersonOversiktStatus
+import no.nav.syfo.personstatus.infrastructure.clients.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.personstatus.infrastructure.cronjob.reaper.ReaperCronjob
 import no.nav.syfo.personstatus.infrastructure.database.queries.getPersonOversiktStatusList
 import no.nav.syfo.testutil.*
@@ -20,15 +25,17 @@ object ReaperCronjobSpek : Spek({
     val externalMockEnvironment = ExternalMockEnvironment.instance
     val database = externalMockEnvironment.database
     val personoversiktStatusService = externalMockEnvironment.personoversiktStatusService
-
+    val behandlendeEnhetClient = mockk<BehandlendeEnhetClient>(relaxed = true)
     val reaperCronjob = ReaperCronjob(
         personOversiktStatusService = personoversiktStatusService,
+        behandlendeEnhetClient = behandlendeEnhetClient,
     )
 
     describe(ReaperCronjobSpek::class.java.simpleName) {
         describe("Successful processing") {
             afterEachTest {
                 database.dropData()
+                clearMocks(behandlendeEnhetClient)
             }
 
             it("reset tildelt veileder for personer with tilfelle that ended two months ago") {
@@ -50,6 +57,9 @@ object ReaperCronjobSpek : Spek({
                 val personOversiktStatuses = database.connection.getPersonOversiktStatusList(personOversiktStatus.fnr)
                 val status = personOversiktStatuses[0]
                 status.veilederIdent shouldBeEqualTo null
+                coVerify(exactly = 1) {
+                    behandlendeEnhetClient.unsetOppfolgingsenhet(any(), PersonIdent(personOversiktStatus.fnr))
+                }
             }
             it("does not reset tildelt veileder for personer with sist_endret less than two months ago") {
                 val threeMonthsAgo = LocalDate.now().minusMonths(3)
@@ -70,6 +80,9 @@ object ReaperCronjobSpek : Spek({
                 val personOversiktStatuses = database.connection.getPersonOversiktStatusList(personOversiktStatus.fnr)
                 val status = personOversiktStatuses[0]
                 status.veilederIdent shouldNotBeEqualTo null
+                coVerify(exactly = 0) {
+                    behandlendeEnhetClient.unsetOppfolgingsenhet(any(), any())
+                }
             }
 
             it("don't process personer with tilfelle that ended less than two months ago") {
@@ -82,6 +95,9 @@ object ReaperCronjobSpek : Spek({
 
                     result.failed shouldBeEqualTo 0
                     result.updated shouldBeEqualTo 0
+                    coVerify(exactly = 0) {
+                        behandlendeEnhetClient.unsetOppfolgingsenhet(any(), any())
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -37,7 +37,7 @@ class ExternalMockEnvironment private constructor() {
 
     val personOversiktStatusRepository = PersonOversiktStatusRepository(database = database)
 
-    val azureAdClient = AzureAdClient(
+    private val azureAdClient = AzureAdClient(
         azureEnvironment = environment.azure,
         valkeyStore = valkeyStore,
         httpClient = mockHttpClient,

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -37,7 +37,7 @@ class ExternalMockEnvironment private constructor() {
 
     val personOversiktStatusRepository = PersonOversiktStatusRepository(database = database)
 
-    private val azureAdClient = AzureAdClient(
+    val azureAdClient = AzureAdClient(
         azureEnvironment = environment.azure,
         valkeyStore = valkeyStore,
         httpClient = mockHttpClient,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Nuller oppfølgingsenhet samtidig med at vi nuller veileder. 

Gjør kallet til syfobehandlendeenhet i alle fall, men hvis det ikke er satt noen oppfølgingsenhet der vil det ikke skje noe. Men hvis den er satt vil vi få et nytt innslag i syfobehandlendeenhet som gjør at vi reverterer tilbake til geografisk enhet.
