### PR TITLE
IS-3171: Oppfolgingsenhet kan være null

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/PersonBehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/PersonBehandlendeEnhetService.kt
@@ -12,24 +12,27 @@ class PersonBehandlendeEnhetService(
         personoversiktStatusRepository.getPersonerWithOppgaveAndOldEnhet()
 
     suspend fun updateBehandlendeEnhet(personIdent: PersonIdent): String? {
-        val behandlendeEnhet = behandlendeEnhetClient.getEnhet(
+        val behandlendeEnhetResponseDTO = behandlendeEnhetClient.getEnhet(
             callId = UUID.randomUUID().toString(),
             personIdent = personIdent,
-        )?.oppfolgingsenhet?.enhetId
+        )
 
-        val tildeltEnhet = personoversiktStatusRepository.getPersonOversiktStatus(personIdent)?.enhet
+        val behandlendeEnhetId = behandlendeEnhetResponseDTO?.oppfolgingsenhet?.enhetId
+            ?: behandlendeEnhetResponseDTO?.geografiskEnhet?.enhetId
 
-        val isEnhetChanged = behandlendeEnhet != tildeltEnhet
-        if (isEnhetChanged && behandlendeEnhet != null) {
+        val tildeltEnhetId = personoversiktStatusRepository.getPersonOversiktStatus(personIdent)?.enhet
+
+        val isEnhetChanged = behandlendeEnhetId != tildeltEnhetId
+        if (isEnhetChanged && behandlendeEnhetId != null) {
             personoversiktStatusRepository.updatePersonTildeltEnhetAndRemoveTildeltVeileder(
                 personIdent = personIdent,
-                enhetId = behandlendeEnhet,
+                enhetId = behandlendeEnhetId,
             )
         } else {
             personoversiktStatusRepository.updatePersonTildeltEnhetUpdatedAt(
                 personIdent = personIdent,
             )
         }
-        return behandlendeEnhet
+        return behandlendeEnhetId
     }
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Tilpasse slik at vi bruker oppfolgingsenhet, men defaulter til geografisk enhet dersom oppfolgingsenhet er null.

Ref https://github.com/navikt/syfobehandlendeenhet/pull/193
