### PR TITLE
IS-3304: Bare nulle oppfolgingsenhet when veileder

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/reaper/ReaperCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/cronjob/reaper/ReaperCronjob.kt
@@ -39,12 +39,14 @@ class ReaperCronjob(
             .forEach {
                 try {
                     val personident = PersonIdent(it.fnr)
-                    personOversiktStatusService.removeTildeltVeileder(personident)
                     personOversiktStatusService.removeTildeltEnhet(personident)
-                    behandlendeEnhetClient.unsetOppfolgingsenhet(
-                        callId = UUID.randomUUID().toString(),
-                        personIdent = personident,
-                    )
+                    if (it.veilederIdent != null) {
+                        personOversiktStatusService.removeTildeltVeileder(personident)
+                        behandlendeEnhetClient.unsetOppfolgingsenhet(
+                            callId = UUID.randomUUID().toString(),
+                            personIdent = personident,
+                        )
+                    }
                     result.updated++
                     COUNT_CRONJOB_REAPER_UPDATE.increment()
                 } catch (ex: Exception) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det er en lang backlog her og cronjob'en slik den er nå går for sakte. Men undøvendig å unset'e oppfølgingsenhet for over en million gamle tilfeller her, så gjøre bare det for de som har tildelt veileder.
