### PR TITLE
IS-3337: Legg til vurderingstype AVSLAG_UTEN_FORHANDSVARSEL

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/arbeidsuforhet/ArbeidsuforhetvurderingDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/arbeidsuforhet/ArbeidsuforhetvurderingDTO.kt
@@ -4,11 +4,11 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class ArbeidsuforhetvurderingerRequestDTO(
-    val personidenter: List<String>
+    val personidenter: List<String>,
 )
 
 data class ArbeidsuforhetvurderingerResponseDTO(
-    val vurderinger: Map<String, ArbeidsuforhetvurderingDTO>
+    val vurderinger: Map<String, ArbeidsuforhetvurderingDTO>,
 )
 
 data class ArbeidsuforhetvurderingDTO(
@@ -22,5 +22,5 @@ data class VarselDTO(
 )
 
 enum class VurderingType {
-    FORHANDSVARSEL, OPPFYLT, AVSLAG, IKKE_AKTUELL
+    FORHANDSVARSEL, OPPFYLT, AVSLAG, IKKE_AKTUELL, AVSLAG_UTEN_FORHANDSVARSEL
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til støtte for arbeidsuforhet vurderingen `AVSLAG_UTEN_FORHANDSVARSEL`

Her kunne vi vurdert å latt være å ha enumen `VurderingType` ettersom `syfooversiktsrv` egentlig bare samler opp masse vurderinger og trenger kanskje ikke å ha en datastruktur for det? 
Risikoen er at vi lager en ny vurderingstype og glemmer å legge inn her – akkurat som jeg gjorde nå 🥲🤠
