### PR TITLE
IS-3330: Add migration for allowing tildelt_veileder to be nullable

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/api/v2/model/VeilederTildelingHistorikkDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/api/v2/model/VeilederTildelingHistorikkDTO.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class VeilederTildelingHistorikkDTO(
     val tildeltDato: LocalDate,
-    val tildeltVeileder: String,
+    val tildeltVeileder: String?,
     val tildeltEnhet: String,
     val tildeltAv: String,
 )

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/VeilederBrukerKnytning.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/VeilederBrukerKnytning.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.personstatus.domain
 
 data class VeilederBrukerKnytning(
-    val veilederIdent: String,
+    val veilederIdent: String?,
     val fnr: String,
 )

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/repository/PersonOversiktStatusRepository.kt
@@ -24,8 +24,8 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
     override fun updateArbeidsuforhetvurderingStatus(
         personident: PersonIdent,
         isAktivVurdering: Boolean,
-    ): Result<Int> {
-        return try {
+    ): Result<Int> =
+        try {
             database.connection.use { connection ->
                 val tidspunkt = Timestamp.from(Instant.now())
                 val uuid = UUID.randomUUID().toString()
@@ -49,7 +49,6 @@ class PersonOversiktStatusRepository(private val database: DatabaseInterface) : 
         } catch (e: Exception) {
             Result.failure(e)
         }
-    }
 
     override fun upsertAktivitetskravAktivStatus(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int> {
         return try {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til muligheten for en sykmeldt å bla satt som ufordelt etter å ha vært tildelt en veileder.

- [x] PR med database migrering må merges før denne

Se [PR med database migrering](https://github.com/navikt/syfooversiktsrv/pull/561) for å tillatte `null` verdi for `tildelt_veileder`
