### PR TITLE
IS-3386: Update flag for aktivitetskrav

### DIFF
--- a/src/main/resources/db/migration/V18_11__fix_aktiv_aktivitetskrav.sql
+++ b/src/main/resources/db/migration/V18_11__fix_aktiv_aktivitetskrav.sql
@@ -1,0 +1,3 @@
+UPDATE person_oversikt_status
+SET is_aktiv_aktivitetskrav_vurdering = false
+WHERE uuid='d78a41b5-7a42-41aa-ab3b-f38fd0749a90';


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Retter opp en forekomst som henger igjen med `is_aktiv_aktivitetskrav_vurdering==true`. Det virker som om publisering til Kafka har sviktet i akkurat dette tilfellet i `isaktivitetskrav`.
