### PR TITLE
IS-3449-3: Consumer for kartleggingssporsmal vurdering endring

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/IPersonOversiktStatusRepository.kt
@@ -19,6 +19,8 @@ interface IPersonOversiktStatusRepository {
 
     fun upsertSenOppfolgingKandidat(personident: PersonIdent, isAktivKandidat: Boolean): Result<Int>
 
+    fun upsertKartleggingssporsmalVurdering(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int>
+
     fun upsertAktivitetskravAktivStatus(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int>
 
     fun upsertManglendeMedvirkningStatus(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int>

--- a/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/application/PersonoversiktStatusService.kt
@@ -125,6 +125,13 @@ class PersonoversiktStatusService(
         )
     }
 
+    fun upsertKartleggingssporsmalVurdering(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int> {
+        return personoversiktStatusRepository.upsertKartleggingssporsmalVurdering(
+            personident = personident,
+            isAktivVurdering = isAktivVurdering,
+        )
+    }
+
     fun upsertAktivitetskravvurderingStatus(personident: PersonIdent, isAktivVurdering: Boolean): Result<Int> =
         personoversiktStatusRepository.upsertAktivitetskravAktivStatus(
             personident = personident,

--- a/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/domain/PersonOversiktStatus.kt
@@ -52,6 +52,9 @@ data class PersonOversiktStatus(
         } else {
             this
         }
+
+    fun updateKartleggingssporsmalVurdering(isAktivVurdering: Boolean): PersonOversiktStatus =
+        this.copy(isAktivKartleggingssporsmalVurdering = isAktivVurdering)
 }
 
 fun PersonOversiktStatus.isDialogmotekandidat() =

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/queries/createOrUpdatePersonOversiktStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/database/queries/createOrUpdatePersonOversiktStatus.kt
@@ -45,8 +45,9 @@ const val queryCreatePersonOversiktStatus =
         friskmelding_til_arbeidsformidling_fom,
         is_aktiv_sen_oppfolging_kandidat,
         is_aktiv_aktivitetskrav_vurdering,
-        is_aktiv_manglende_medvirkning_vurdering
-    ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        is_aktiv_manglende_medvirkning_vurdering,
+        is_aktiv_kartleggingssporsmal_vurdering
+    ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     RETURNING *
     """
 
@@ -114,6 +115,7 @@ fun Connection.createPersonOversiktStatus(
         it.setBoolean(parameterIndex++, personOversiktStatus.isAktivSenOppfolgingKandidat)
         it.setBoolean(parameterIndex++, personOversiktStatus.isAktivAktivitetskravvurdering)
         it.setBoolean(parameterIndex++, personOversiktStatus.isAktivManglendeMedvirkningVurdering)
+        it.setBoolean(parameterIndex++, personOversiktStatus.isAktivKartleggingssporsmalVurdering)
         it.executeQuery().toList { toPPersonOversiktStatus() }.firstOrNull()
     } ?: throw SQLException("Creating PersonOversikStatus failed, no rows affected.")
 

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/KafkaModule.kt
@@ -17,7 +17,7 @@ import no.nav.syfo.personstatus.application.OppfolgingstilfelleService
 import no.nav.syfo.personstatus.application.oppfolgingsoppgave.OppfolgingsoppgaveService
 import no.nav.syfo.personstatus.infrastructure.kafka.behandlendeenhet.BehandlendeEnhetConsumer
 import no.nav.syfo.personstatus.infrastructure.kafka.manglendemedvirkning.ManglendeMedvirkningVurderingConsumer
-import no.nav.syfo.personstatus.infrastructure.kafka.meroppfolging.SenOppfolgingKandidatStatusConsumer
+import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase.SenOppfolgingKandidatStatusConsumer
 import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsoppgave.launchOppfolgingsoppgaveConsumer
 
 fun launchKafkaModule(

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/kartleggingssporsmal/KartleggingssporsmalKandidatConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/kartleggingssporsmal/KartleggingssporsmalKandidatConsumer.kt
@@ -1,0 +1,73 @@
+package no.nav.syfo.personstatus.infrastructure.kafka.kartleggingssporsmal
+
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.personstatus.application.PersonoversiktStatusService
+import no.nav.syfo.personstatus.domain.PersonIdent
+import no.nav.syfo.personstatus.infrastructure.kafka.*
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.Deserializer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.*
+
+class KartleggingssporsmalKandidatConsumer(
+    private val personoversiktStatusService: PersonoversiktStatusService,
+) : KafkaConsumerService<KartleggingssporsmalKandidatRecord> {
+
+    override val pollDurationInMillis: Long = 1000
+
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KartleggingssporsmalKandidatRecord>) {
+        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            log.info("KartleggingssporsmalKandidatConsumer trace: Received ${records.count()} records")
+            processRecords(records = records)
+            kafkaConsumer.commitSync()
+        }
+    }
+
+    // TODO: Legg til hvordan dette blir en "aktiv" vurdering
+    private fun processRecords(records: ConsumerRecords<String, KartleggingssporsmalKandidatRecord>): List<Result<Int>> {
+        val validRecords = records.requireNoNulls()
+        return validRecords.map { record ->
+            val recordValue = record.value()
+            personoversiktStatusService.upsertKartleggingssporsmalVurdering(
+                personident = PersonIdent(recordValue.personident),
+                isAktivVurdering = false,
+            )
+        }
+    }
+
+    fun start(applicationState: ApplicationState, kafkaEnvironment: KafkaEnvironment) {
+        val consumerProperties = Properties().apply {
+            putAll(kafkaAivenConsumerConfig(kafkaEnvironment = kafkaEnvironment))
+            this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
+                KandidatStatusRecordDeserializer::class.java.canonicalName
+        }
+        launchKafkaTask(
+            applicationState = applicationState,
+            kafkaConsumerService = this,
+            consumerProperties = consumerProperties,
+            topic = KARTLEGGINGSSPORSMAL_KANDIDAT_STATUS_TOPIC,
+        )
+    }
+
+    companion object {
+        const val KARTLEGGINGSSPORSMAL_KANDIDAT_STATUS_TOPIC = "teamsykefravr.ismeroppfolging-kartleggingssporsmal-kandidat"
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}
+
+data class KartleggingssporsmalKandidatRecord(
+    val uuid: UUID,
+    val personident: String,
+)
+
+class KandidatStatusRecordDeserializer : Deserializer<KartleggingssporsmalKandidatRecord> {
+    private val mapper = configuredJacksonMapper()
+    override fun deserialize(topic: String, data: ByteArray): KartleggingssporsmalKandidatRecord =
+        mapper.readValue(data, KartleggingssporsmalKandidatRecord::class.java)
+}

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/oppfolgingsenfase/KandidatStatusRecord.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/oppfolgingsenfase/KandidatStatusRecord.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus.infrastructure.kafka.meroppfolging
+package no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase
 
 import java.time.OffsetDateTime
 import java.util.UUID

--- a/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/oppfolgingsenfase/SenOppfolgingKandidatStatusConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/oppfolgingsenfase/SenOppfolgingKandidatStatusConsumer.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.personstatus.infrastructure.kafka.meroppfolging
+package no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase
 
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.personstatus.application.PersonoversiktStatusService

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/database/PersonOversiktStatusRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/database/PersonOversiktStatusRepositoryTest.kt
@@ -36,6 +36,7 @@ class PersonOversiktStatusRepositoryTest {
     private val externalMockEnvironment = ExternalMockEnvironment.instance
     private val database = externalMockEnvironment.database
     private val personOversiktStatusRepository = externalMockEnvironment.personOversiktStatusRepository
+    private val arbeidstakerFnr = PersonIdent(UserConstants.ARBEIDSTAKER_FNR)
 
     @BeforeEach
     fun setUp() {
@@ -97,7 +98,7 @@ class PersonOversiktStatusRepositoryTest {
         @Test
         fun `Creates new person when none exist when updating arbeidsuforhet vurdering status`() {
             val result = personOversiktStatusRepository.updateArbeidsuforhetvurderingStatus(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivVurdering = false
             )
 
@@ -122,7 +123,7 @@ class PersonOversiktStatusRepositoryTest {
             }
 
             val result = personOversiktStatusRepository.upsertSenOppfolgingKandidat(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivKandidat = true,
             )
 
@@ -144,7 +145,7 @@ class PersonOversiktStatusRepositoryTest {
             }
 
             val result = personOversiktStatusRepository.upsertSenOppfolgingKandidat(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivKandidat = false,
             )
 
@@ -157,12 +158,67 @@ class PersonOversiktStatusRepositoryTest {
         @Test
         fun `Creates new person when none exist when upserting mer oppfolging kandidat status`() {
             val result = personOversiktStatusRepository.upsertSenOppfolgingKandidat(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivKandidat = true,
             )
 
             val pPersonOversiktStatus = database.getPersonOversiktStatusList(fnr = UserConstants.ARBEIDSTAKER_FNR)
             assertTrue(pPersonOversiktStatus.isNotEmpty())
+            assertTrue(result.isSuccess)
+        }
+    }
+
+    @Nested
+    @DisplayName("Upsert kartleggingsspormal vurdering")
+    inner class UpsertKartleggingssporsmalVurdering {
+        @Test
+        fun `Successfully updates kartleggingssporsmal vurdering status to active`() {
+            val newPersonOversiktStatus = PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR)
+            personOversiktStatusRepository.createPersonOversiktStatus(newPersonOversiktStatus)
+
+            val result = personOversiktStatusRepository.upsertKartleggingssporsmalVurdering(
+                personident = arbeidstakerFnr,
+                isAktivVurdering = true,
+            )
+
+            assertTrue(result.isSuccess)
+            val pPersonOversiktStatus = personOversiktStatusRepository.getPersonOversiktStatus(personident = arbeidstakerFnr)!!
+            assertNotEquals(
+                newPersonOversiktStatus.isAktivKartleggingssporsmalVurdering,
+                pPersonOversiktStatus.isAktivKartleggingssporsmalVurdering
+            )
+            assertTrue(pPersonOversiktStatus.isAktivKartleggingssporsmalVurdering)
+        }
+
+        @Test
+        fun `Successfully updates kartleggingssporsmal vurdering status from active to not active`() {
+            val newPersonOversiktStatus = PersonOversiktStatus(fnr = UserConstants.ARBEIDSTAKER_FNR)
+                .copy(isAktivKartleggingssporsmalVurdering = true)
+            personOversiktStatusRepository.createPersonOversiktStatus(newPersonOversiktStatus)
+
+            val result = personOversiktStatusRepository.upsertKartleggingssporsmalVurdering(
+                personident = arbeidstakerFnr,
+                isAktivVurdering = false,
+            )
+
+            assertTrue(result.isSuccess)
+            val pPersonOversiktStatus = personOversiktStatusRepository.getPersonOversiktStatus(personident = arbeidstakerFnr)!!
+            assertNotEquals(
+                newPersonOversiktStatus.isAktivKartleggingssporsmalVurdering,
+                pPersonOversiktStatus.isAktivKartleggingssporsmalVurdering
+            )
+            assertFalse(pPersonOversiktStatus.isAktivKartleggingssporsmalVurdering)
+        }
+
+        @Test
+        fun `Creates new person when none exist when upserting kartleggingssporsmal vurdering status`() {
+            val result = personOversiktStatusRepository.upsertKartleggingssporsmalVurdering(
+                personident = arbeidstakerFnr,
+                isAktivVurdering = true,
+            )
+
+            val pPersonOversiktStatus = personOversiktStatusRepository.getPersonOversiktStatus(personident = arbeidstakerFnr)
+            assertNotNull(pPersonOversiktStatus)
             assertTrue(result.isSuccess)
         }
     }
@@ -183,7 +239,7 @@ class PersonOversiktStatusRepositoryTest {
             }
 
             val personStatus =
-                personOversiktStatusRepository.getPersonOversiktStatus(PersonIdent(UserConstants.ARBEIDSTAKER_FNR))
+                personOversiktStatusRepository.getPersonOversiktStatus(arbeidstakerFnr)
             assertNotNull(personStatus)
             assertEquals(newPersonOversiktStatus.fnr, personStatus?.fnr)
             assertEquals(fodselsdato, personStatus?.fodselsdato)
@@ -192,7 +248,7 @@ class PersonOversiktStatusRepositoryTest {
         @Test
         fun `Handles trying to retrieve non existing person oversikt status`() {
             val personStatus =
-                personOversiktStatusRepository.getPersonOversiktStatus(PersonIdent(UserConstants.ARBEIDSTAKER_FNR))
+                personOversiktStatusRepository.getPersonOversiktStatus(arbeidstakerFnr)
 
             assertNull(personStatus)
         }
@@ -213,7 +269,7 @@ class PersonOversiktStatusRepositoryTest {
             }
 
             val result = personOversiktStatusRepository.upsertAktivitetskravAktivStatus(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivVurdering = true,
             )
 
@@ -235,25 +291,26 @@ class PersonOversiktStatusRepositoryTest {
             }
 
             val result = personOversiktStatusRepository.upsertAktivitetskravAktivStatus(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivVurdering = false,
             )
 
             assertTrue(result.isSuccess)
-            val pPersonOversiktStatus = database.getPersonOversiktStatusList(fnr = UserConstants.ARBEIDSTAKER_FNR).first()
+            val pPersonOversiktStatus = personOversiktStatusRepository.getPersonOversiktStatus(personident = arbeidstakerFnr)!!
             assertNotEquals(newPersonOversiktStatus.isAktivAktivitetskravvurdering, pPersonOversiktStatus.isAktivAktivitetskravvurdering)
             assertFalse(pPersonOversiktStatus.isAktivAktivitetskravvurdering)
         }
 
         @Test
-        fun `Creates new person when none exist when upserting mer oppfolging kandidat status`() {
+        fun `Creates new person when none exist when upserting aktivitetskrav status`() {
             val result = personOversiktStatusRepository.upsertAktivitetskravAktivStatus(
-                personident = PersonIdent(UserConstants.ARBEIDSTAKER_FNR),
+                personident = arbeidstakerFnr,
                 isAktivVurdering = true,
             )
 
-            val pPersonOversiktStatus = database.getPersonOversiktStatusList(fnr = UserConstants.ARBEIDSTAKER_FNR)
-            assertTrue(pPersonOversiktStatus.isNotEmpty())
+            val pPersonOversiktStatus =
+                personOversiktStatusRepository.getPersonOversiktStatus(personident = arbeidstakerFnr)
+            assertNotNull(pPersonOversiktStatus)
             assertTrue(result.isSuccess)
         }
     }

--- a/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/personstatus/infrastructure/kafka/meroppfolging/SenOppfolgingKandidatStatusConsumerTest.kt
@@ -9,6 +9,10 @@ import no.nav.syfo.personstatus.domain.PersonOversiktStatus
 import no.nav.syfo.personstatus.infrastructure.database.queries.createPersonOversiktStatus
 import no.nav.syfo.personstatus.infrastructure.database.queries.getPersonOversiktStatusList
 import no.nav.syfo.personstatus.infrastructure.kafka.mockPollConsumerRecords
+import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase.KandidatStatusRecord
+import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase.SenOppfolgingKandidatStatusConsumer
+import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase.Status
+import no.nav.syfo.personstatus.infrastructure.kafka.oppfolgingsenfase.StatusDTO
 import no.nav.syfo.testutil.ExternalMockEnvironment
 import no.nav.syfo.testutil.UserConstants
 import org.apache.kafka.clients.consumer.KafkaConsumer


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til consumer for å ta i mot kartleggingsspørsmål fra topic som `ismeroppfolging` produserer til og oppdaterer db slik at kartleggingsspørsmål vurdering blir aktiv og derfor kan vises i oversikten.

Gjenstår å lande hvordan man setter vurdering til aktiv fra record. La inn kommentar på dette.
Se [tilhørende PR](https://github.com/navikt/ismeroppfolging/pull/140) i `ismeroppfolging`
