### PR TITLE
IS-3953: Redusere samtidighetskonflikter

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/dialogmotekandidat/DialogmotekandidatEndringConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/dialogmotekandidat/DialogmotekandidatEndringConsumer.kt
@@ -10,7 +10,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.LoggerFactory
 import java.sql.Connection
-import java.sql.SQLException
 import java.time.Duration
 
 class DialogmotekandidatEndringConsumer(
@@ -39,10 +38,10 @@ class DialogmotekandidatEndringConsumer(
             COUNT_KAFKA_CONSUMER_DIALOGMOTEKANDIDAT_TOMBSTONE.increment(numberOfTombstones.toDouble())
         }
 
-        transactionManager.transaction { connection ->
-            validRecords.forEach { record ->
-                COUNT_KAFKA_CONSUMER_DIALOGMOTEKANDIDAT_READ.increment()
-                log.info("Received ${KafkaDialogmotekandidatEndring::class.java.simpleName} with key=${record.key()}, ready to process.")
+        validRecords.forEach { record ->
+            COUNT_KAFKA_CONSUMER_DIALOGMOTEKANDIDAT_READ.increment()
+            log.info("Received ${KafkaDialogmotekandidatEndring::class.java.simpleName} with key=${record.key()}, ready to process.")
+            transactionManager.transaction { connection ->
                 receiveKafkaDialogmotekandidatEndring(
                     connection = connection,
                     kafkaDialogmotekandidatEndring = record.value()
@@ -73,21 +72,11 @@ class DialogmotekandidatEndringConsumer(
                 kafkaDialogmotekandidatEndring.createdAt.isAfter(it)
             } ?: true
             if (shouldUpdateKandidat) {
-                try {
-                    connection.updatePersonOversiktStatusKandidat(
-                        personident = PersonIdent(existingPersonOversiktStatus.fnr),
-                        kandidat = kafkaDialogmotekandidatEndring.kandidat,
-                        generatedAt = kafkaDialogmotekandidatEndring.createdAt,
-                    )
-                } catch (sqlException: SQLException) {
-                    // retry once before giving up (could be database concurrency conflict)
-                    log.info("Got sqlException when receiveKafkaDialogmotekandidatEndring, try again")
-                    connection.updatePersonOversiktStatusKandidat(
-                        personident = PersonIdent(existingPersonOversiktStatus.fnr),
-                        kandidat = kafkaDialogmotekandidatEndring.kandidat,
-                        generatedAt = kafkaDialogmotekandidatEndring.createdAt,
-                    )
-                }
+                connection.updatePersonOversiktStatusKandidat(
+                    personident = PersonIdent(existingPersonOversiktStatus.fnr),
+                    kandidat = kafkaDialogmotekandidatEndring.kandidat,
+                    generatedAt = kafkaDialogmotekandidatEndring.createdAt,
+                )
                 COUNT_KAFKA_CONSUMER_DIALOGMOTEKANDIDAT_UPDATED_PERSONOVERSIKT_STATUS.increment()
             }
         }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/dialogmotestatusendring/DialogmoteStatusendringConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/dialogmotestatusendring/DialogmoteStatusendringConsumer.kt
@@ -12,7 +12,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.LoggerFactory
 import java.sql.Connection
-import java.sql.SQLException
 import java.time.Duration
 
 class DialogmoteStatusendringConsumer(
@@ -38,10 +37,10 @@ class DialogmoteStatusendringConsumer(
             COUNT_KAFKA_CONSUMER_DIALOGMOTE_STATUSENDRING_TOMBSTONE.increment(numberOfTombstones.toDouble())
         }
 
-        transactionManager.transaction { connection ->
-            validRecords.forEach { record ->
-                COUNT_KAFKA_CONSUMER_DIALOGMOTE_STATUSENDRING_READ.increment()
-                log.info("Received ${KDialogmoteStatusEndring::class.java.simpleName} record with key: ${record.key()}")
+        validRecords.forEach { record ->
+            COUNT_KAFKA_CONSUMER_DIALOGMOTE_STATUSENDRING_READ.increment()
+            log.info("Received ${KDialogmoteStatusEndring::class.java.simpleName} record with key: ${record.key()}")
+            transactionManager.transaction { connection ->
                 receiveKafkaDialogmoteStatusEndring(
                     connection = connection,
                     kafkaDialogmoteStatusEndring = record.value(),
@@ -73,19 +72,10 @@ class DialogmoteStatusendringConsumer(
                 dialogmoteStatusEndring.endringTidspunkt.isAfter(it)
             } ?: true
             if (shouldUpdateMotestatus) {
-                try {
-                    connection.updatePersonOversiktStatusMotestatus(
-                        personident = PersonIdent(existingPersonOversiktStatus.fnr),
-                        dialogmoteStatusendring = dialogmoteStatusEndring,
-                    )
-                } catch (sqlException: SQLException) {
-                    // retry
-                    log.info("Got sqlException when receiveKafkaDialogmoteStatusEndring, try again")
-                    connection.updatePersonOversiktStatusMotestatus(
-                        personident = PersonIdent(existingPersonOversiktStatus.fnr),
-                        dialogmoteStatusendring = dialogmoteStatusEndring,
-                    )
-                }
+                connection.updatePersonOversiktStatusMotestatus(
+                    personident = PersonIdent(existingPersonOversiktStatus.fnr),
+                    dialogmoteStatusendring = dialogmoteStatusEndring,
+                )
                 COUNT_KAFKA_CONSUMER_DIALOGMOTE_STATUSENDRING_UPDATED_PERSONOVERSIKT_STATUS.increment()
             }
         }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/frisktilarbeid/FriskTilArbeidVedtakConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/frisktilarbeid/FriskTilArbeidVedtakConsumer.kt
@@ -38,16 +38,16 @@ class FriskTilArbeidVedtakConsumer(
             log.error("Value of $numberOfTombstones ConsumerRecord are null, most probably due to a tombstone. Contact the owner of the topic if an error is suspected")
         }
 
-        transactionManager.transaction { connection ->
-            validRecords.forEach { record ->
-                log.info("Received ${VedtakStatusRecord::class.java.simpleName} with key=${record.key()}, ready to process.")
-                val vedtak = record.value()
+        validRecords.forEach { record ->
+            log.info("Received ${VedtakStatusRecord::class.java.simpleName} with key=${record.key()}, ready to process.")
+            val vedtak = record.value()
+            transactionManager.transaction { connection ->
                 receiveKafkaFriskTilArbeidVedtak(
                     connection = connection,
                     vedtakStatusRecord = vedtak,
                 )
-                COUNT_KAFKA_CONSUMER_FRISKTILARBEID_READ.increment()
             }
+            COUNT_KAFKA_CONSUMER_FRISKTILARBEID_READ.increment()
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/frisktilarbeid/FriskTilArbeidVedtakConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/frisktilarbeid/FriskTilArbeidVedtakConsumer.kt
@@ -40,6 +40,7 @@ class FriskTilArbeidVedtakConsumer(
 
         validRecords.forEach { record ->
             log.info("Received ${VedtakStatusRecord::class.java.simpleName} with key=${record.key()}, ready to process.")
+            COUNT_KAFKA_CONSUMER_FRISKTILARBEID_READ.increment()
             val vedtak = record.value()
             transactionManager.transaction { connection ->
                 receiveKafkaFriskTilArbeidVedtak(
@@ -47,7 +48,6 @@ class FriskTilArbeidVedtakConsumer(
                     vedtakStatusRecord = vedtak,
                 )
             }
-            COUNT_KAFKA_CONSUMER_FRISKTILARBEID_READ.increment()
         }
     }
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi får den del samtidighetskonflikter i Kafka-consumerne - antakelig fordi vi får langvarige db-transaksjoner når det kommer flere Kafka-records i en batch. For å forbedre dette kan vi commite mot databasen fortløpende for hver record - dette går bra siden vi i disse consumerne tåler godt at records eventuelt kommer på nytt.
