### PR TITLE
IS-4184: delete duplicate row from oversikt

### DIFF
--- a/src/main/resources/db/migration/V18_16__delete_person_oversikt_status_row.sql
+++ b/src/main/resources/db/migration/V18_16__delete_person_oversikt_status_row.sql
@@ -1,0 +1,2 @@
+DELETE from person_oversikt_status
+WHERE uuid = 'f495854d-c4e7-4be9-ad36-5995d6e8e6b8';


### PR DESCRIPTION
https://jira.adeo.no/browse/FAGSYSTEM-442216

Personen har to rader i `person_oversikt_status`, et med DNR og et med FNR. Litt usikker på hvordan det kan ha skjedd, siden vi lytter til personhendelser.

Har også sjekket noen andre databaser for å se om det er flere innslag med DNR:
- [X] ishuskelapp
- [X] isdialogmotekandidat
- [X] isaktivitetskrav
- [X] isdialogmelding
- [X] isoppfolgingstilfelle (her var det 2 biter som fortsatt hadde DNR. Dette var sykepengesøknader som ikke påvirket lengde på oppfølgingstilfellet)